### PR TITLE
feat: add market radar tab experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Market Radar</title>
+  </head>
+  <body class="bg-slate-950">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "market-radar",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "test": "vitest",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "d3-geo": "^3.1.0",
+    "clsx": "^2.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.5.1",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "autoprefixer": "^10.4.16",
+    "jsdom": "^22.1.0",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vitest": "^0.34.6"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/AcquisitionDemoApp.tsx
+++ b/src/AcquisitionDemoApp.tsx
@@ -1,0 +1,122 @@
+/**
+ * AcquisitionDemoApp stitches the Market Radar and Segment Studio tabs with a hash router.
+ */
+import React, { useEffect, useMemo, useState } from "react";
+import MarketRadarWireframe from "./marketRadar/MarketRadarWireframe";
+import SegmentStudioWireframe from "./SegmentStudioWireframe";
+import { SegmentPayload, loadAll } from "./storage";
+
+type Route = { name: "radar" } | { name: "studio"; id: string | null };
+
+const parseHash = (): Route => {
+  if (typeof window === "undefined") {
+    return { name: "radar" };
+  }
+  const hash = window.location.hash || "";
+  if (!hash) {
+    return { name: "radar" };
+  }
+  const clean = hash.replace(/^#/, "");
+  const parts = clean.split("/").filter(Boolean);
+  if (parts[0] === "studio") {
+    return { name: "studio", id: parts[1] ?? null };
+  }
+  return { name: "radar" };
+};
+
+const AcquisitionDemoApp: React.FC = () => {
+  const [route, setRoute] = useState<Route>(() => parseHash());
+  const [lastSegmentId, setLastSegmentId] = useState<string | null>(() => {
+    const all = loadAll();
+    if (all.length === 0) {
+      return null;
+    }
+    const sorted = [...all].sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1));
+    return sorted[0]?.id ?? null;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (!window.location.hash) {
+      window.location.hash = "#/radar";
+    }
+    const handle = () => {
+      setRoute(parseHash());
+      const all = loadAll();
+      if (all.length > 0) {
+        const sorted = [...all].sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1));
+        setLastSegmentId(sorted[0]?.id ?? null);
+      }
+    };
+    window.addEventListener("hashchange", handle);
+    handle();
+    return () => window.removeEventListener("hashchange", handle);
+  }, []);
+
+  const nav = useMemo(() => route.name, [route]);
+
+  const navigateToStudio = () => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (route.name === "studio" && route.id) {
+      window.location.hash = `#/studio/${route.id}`;
+      return;
+    }
+    if (lastSegmentId) {
+      window.location.hash = `#/studio/${lastSegmentId}`;
+    } else {
+      window.location.hash = "#/studio";
+    }
+  };
+
+  const handleExport = (payload: SegmentPayload) => {
+    setLastSegmentId(payload.id);
+    setRoute({ name: "studio", id: payload.id });
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <nav className="sticky top-0 z-40 border-b border-slate-800 bg-slate-950/95 backdrop-blur">
+        <div className="mx-auto flex max-w-7xl items-center gap-4 px-6 py-4">
+          <h1 className="text-lg font-semibold text-white">Acquisition Demo</h1>
+          <div className="flex items-center gap-2 text-sm">
+            <button
+              type="button"
+              data-testid="nav-radar"
+              className={`focus-outline rounded-full px-3 py-1 font-semibold transition ${
+                nav === "radar" ? "bg-emerald-500 text-slate-900" : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+              }`}
+              onClick={() => {
+                if (typeof window !== "undefined") {
+                  window.location.hash = "#/radar";
+                }
+              }}
+            >
+              Market Radar
+            </button>
+            <button
+              type="button"
+              data-testid="nav-studio"
+              className={`focus-outline rounded-full px-3 py-1 font-semibold transition ${
+                nav === "studio" ? "bg-emerald-500 text-slate-900" : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+              }`}
+              onClick={navigateToStudio}
+            >
+              Segment Studio
+            </button>
+          </div>
+        </div>
+      </nav>
+      {route.name === "radar" ? (
+        <MarketRadarWireframe onExport={handleExport} />
+      ) : (
+        <SegmentStudioWireframe activeId={route.id ?? lastSegmentId} />
+      )}
+    </div>
+  );
+};
+
+export default AcquisitionDemoApp;

--- a/src/SegmentStudioWireframe.tsx
+++ b/src/SegmentStudioWireframe.tsx
@@ -1,0 +1,678 @@
+/**
+ * SegmentStudioWireframe reads Market Radar exports and provides a lite rules builder and readiness view.
+ */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Badge, Meter } from "./marketRadar/components/atoms";
+import { SegmentPayload, getOne, loadAll, saveOne } from "./storage";
+
+const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n));
+const round = (n: number) => Math.round(n);
+const fmtK = (n: number) => {
+  if (n >= 1000) {
+    const value = Math.round(n / 100) / 10;
+    return `${value % 1 === 0 ? value.toFixed(0) : value.toFixed(1)}k`;
+  }
+  return `${n}`;
+};
+const calcDest = (net: number) => ({
+  email: round(net * 0.37),
+  social: round(net * 0.3),
+  sms: round(net * 0.24)
+});
+
+type Props = {
+  activeId?: string | null;
+};
+
+type StepKey = "step1" | "step2" | "step3";
+
+type StepState = Record<StepKey, boolean>;
+
+const emptyStepState: StepState = { step1: false, step2: false, step3: false };
+
+const SegmentStudioWireframe: React.FC<Props> = ({ activeId }) => {
+  const [payload, setPayload] = useState<SegmentPayload | null>(null);
+  const [missing, setMissing] = useState(false);
+  const [includeChips, setIncludeChips] = useState<string[]>([]);
+  const [excludeChips, setExcludeChips] = useState<string[]>([]);
+  const [includeInput, setIncludeInput] = useState("");
+  const [excludeInput, setExcludeInput] = useState("");
+  const [includeLogic, setIncludeLogic] = useState<"AND" | "OR">("AND");
+  const [dedupGrain, setDedupGrain] = useState<"Household" | "Person">("Household");
+  const [holdout, setHoldout] = useState(10);
+  const [suppressionsApplied, setSuppressionsApplied] = useState(false);
+  const [contactPermissions, setContactPermissions] = useState(true);
+  const [stepChecks, setStepChecks] = useState<StepState>(emptyStepState);
+  const [stepToast, setStepToast] = useState<StepState>(emptyStepState);
+  const stepTimers = useRef<Record<StepKey, ReturnType<typeof setTimeout> | null>>({
+    step1: null,
+    step2: null,
+    step3: null
+  });
+  const baseline = useRef<{ include: string[]; exclude: string[] }>({ include: [], exclude: [] });
+  const [lineageOpen, setLineageOpen] = useState(false);
+  const lastHydratedId = useRef<string | null>(null);
+  const includeMarker = useRef(includeChips.length + excludeChips.length);
+  const prevNet = useRef(0);
+  const prevReadiness = useRef(0);
+  const prevContact = useRef(contactPermissions);
+  const prevGrain = useRef(dedupGrain);
+
+  const baseReach = payload?.kpis.reachable ?? 0;
+
+  const scoreNet = useCallback(
+    (
+      reach: number,
+      grain: "Household" | "Person",
+      includes: string[],
+      excludes: string[],
+      hold: number,
+      suppression: boolean
+    ) => {
+      if (!reach) {
+        return 0;
+      }
+      let net = grain === "Person" ? reach * 1.06 : reach;
+      const includeBonus = clamp(includes.length * 0.01, 0, 0.1);
+      const excludePenalty = clamp(excludes.length * 0.015, 0, 0.2);
+      net = net * (1 + includeBonus - excludePenalty);
+      net = net * (1 - hold / 100);
+      if (suppression) {
+        net = net * 0.94;
+      }
+      return clamp(Math.round(net), 0, 300000);
+    },
+    []
+  );
+
+  const netEligible = useMemo(
+    () => scoreNet(baseReach, dedupGrain, includeChips, excludeChips, holdout, suppressionsApplied),
+    [baseReach, dedupGrain, includeChips, excludeChips, holdout, suppressionsApplied, scoreNet]
+  );
+
+  const destinations = useMemo(() => calcDest(netEligible), [netEligible]);
+
+  const readinessScore = useMemo(() => {
+    const passes = [true, contactPermissions, true, suppressionsApplied];
+    const count = passes.filter(Boolean).length;
+    return Math.round((count / 4) * 100);
+  }, [contactPermissions, suppressionsApplied]);
+
+  const triggerStep = (key: StepKey) => {
+    setStepChecks((prev) => ({ ...prev, [key]: !prev[key] }));
+    setStepToast((prev) => ({ ...prev, [key]: true }));
+    if (stepTimers.current[key]) {
+      clearTimeout(stepTimers.current[key] as ReturnType<typeof setTimeout>);
+    }
+    stepTimers.current[key] = setTimeout(() => {
+      setStepToast((prev) => ({ ...prev, [key]: false }));
+    }, 2000);
+  };
+
+  const hydrate = useCallback(
+    (id: string | null) => {
+      if (!id) {
+        setPayload(null);
+        setMissing(true);
+        lastHydratedId.current = null;
+        return;
+      }
+      if (lastHydratedId.current === id) {
+        return;
+      }
+      const found = getOne(id);
+      if (!found) {
+        setPayload(null);
+        setMissing(true);
+        lastHydratedId.current = id;
+        return;
+      }
+      lastHydratedId.current = id;
+      setPayload(found);
+      setMissing(false);
+      const seededInclude = found.chips.slice(0, 2);
+      const seededExclude = found.rivals?.slice(0, 1) ?? [];
+      setIncludeChips(seededInclude);
+      setExcludeChips(seededExclude);
+      setIncludeInput("");
+      setExcludeInput("");
+      setHoldout(10);
+      setSuppressionsApplied(false);
+      setContactPermissions(true);
+      setIncludeLogic("AND");
+      setDedupGrain("Household");
+      setStepChecks(emptyStepState);
+      setStepToast(emptyStepState);
+      baseline.current = { include: seededInclude, exclude: seededExclude };
+    },
+    []
+  );
+
+  const parseHashId = useCallback(() => {
+    if (typeof window === "undefined") {
+      hydrate(activeId ?? null);
+      return;
+    }
+    const hash = window.location.hash.replace(/^#/, "");
+    const parts = hash.split("/").filter(Boolean);
+    if (parts[0] === "studio") {
+      hydrate(parts[1] ?? activeId ?? null);
+    } else {
+      hydrate(activeId ?? null);
+    }
+  }, [activeId, hydrate]);
+
+  useEffect(() => {
+    parseHashId();
+    if (typeof window === "undefined") {
+      return;
+    }
+    const handler = () => parseHashId();
+    window.addEventListener("hashchange", handler);
+    return () => window.removeEventListener("hashchange", handler);
+  }, [parseHashId]);
+
+  useEffect(() => {
+    if (activeId) {
+      hydrate(activeId);
+    }
+  }, [activeId, hydrate]);
+
+  useEffect(() => {
+    includeMarker.current = includeChips.length + excludeChips.length;
+  }, []);
+
+  useEffect(() => {
+    const changeMarker = includeChips.length + excludeChips.length;
+    const previousNet = prevNet.current;
+    const previousReadiness = prevReadiness.current;
+    const previousContact = prevContact.current;
+    const previousGrain = prevGrain.current;
+    if (changeMarker !== includeMarker.current && previousNet === netEligible) {
+      console.warn("Chip updates should influence net eligible counts");
+    }
+    if (readinessScore < 0 || readinessScore > 100) {
+      console.warn("Readiness score out of expected range");
+    }
+    if (previousContact !== contactPermissions && previousReadiness === readinessScore) {
+      console.warn("Contact permissions toggle should adjust readiness score");
+    }
+    if (previousGrain !== dedupGrain && previousNet === netEligible) {
+      console.warn("Dedup grain toggle should shift net eligible base");
+    }
+    includeMarker.current = changeMarker;
+    prevNet.current = netEligible;
+    prevReadiness.current = readinessScore;
+    prevContact.current = contactPermissions;
+    prevGrain.current = dedupGrain;
+  }, [includeChips, excludeChips, netEligible, readinessScore, contactPermissions, dedupGrain]);
+
+  const addChip = (bucket: "include" | "exclude") => {
+    const value = bucket === "include" ? includeInput.trim() : excludeInput.trim();
+    if (!value) {
+      return;
+    }
+    if (bucket === "include") {
+      if (!includeChips.includes(value)) {
+        setIncludeChips((prev) => [...prev, value]);
+      }
+      setIncludeInput("");
+    } else {
+      if (!excludeChips.includes(value)) {
+        setExcludeChips((prev) => [...prev, value]);
+      }
+      setExcludeInput("");
+    }
+  };
+
+  const diff = useMemo(() => {
+    const includeAdded = includeChips.filter((chip) => !baseline.current.include.includes(chip));
+    const includeRemoved = baseline.current.include.filter((chip) => !includeChips.includes(chip));
+    const excludeAdded = excludeChips.filter((chip) => !baseline.current.exclude.includes(chip));
+    const excludeRemoved = baseline.current.exclude.filter((chip) => !excludeChips.includes(chip));
+    return { includeAdded, includeRemoved, excludeAdded, excludeRemoved };
+  }, [includeChips, excludeChips]);
+
+  const delta = netEligible - baseReach;
+  const deltaLabel = `${delta >= 0 ? "+" : "-"}${fmtK(Math.abs(delta))}`;
+
+  const readinessRows = [
+    { label: "Coverage >= 80%", pass: true },
+    { label: "Consent >= 95%", pass: contactPermissions },
+    { label: "Dedup loss <= 12%", pass: true },
+    { label: "Overlap <= 15%", pass: suppressionsApplied }
+  ];
+
+  const emptyImport = () => {
+    const all = loadAll();
+    if (all.length === 0) {
+      return;
+    }
+    const sorted = [...all].sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1));
+    if (typeof window !== "undefined") {
+      window.location.hash = `#/studio/${sorted[0].id}`;
+    }
+  };
+
+  const lockCohort = () => {
+    if (!payload) {
+      return;
+    }
+    const updated: SegmentPayload = { ...payload, version: payload.version + 1 };
+    setPayload(updated);
+    saveOne(updated);
+  };
+
+  const lineageSummary = [
+    diff.includeAdded.length > 0 ? `+${diff.includeAdded.join(", ")}` : null,
+    diff.includeRemoved.length > 0 ? `-${diff.includeRemoved.join(", ")}` : null,
+    diff.excludeAdded.length > 0 ? `+EX ${diff.excludeAdded.join(", ")}` : null,
+    diff.excludeRemoved.length > 0 ? `-EX ${diff.excludeRemoved.join(", ")}` : null
+  ]
+    .filter(Boolean)
+    .join(" • ");
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 pb-24 text-slate-50">
+      <div className="mx-auto max-w-7xl px-6 py-10 space-y-6">
+        <header className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold text-white">Segment Studio</h2>
+            {payload && <span className="text-xs text-slate-400">Version {payload.version}</span>}
+          </div>
+          <p className="text-sm text-slate-300">
+            Refine the read-in cohort, apply governance checks, and preview destinations before locking.
+          </p>
+        </header>
+
+        <div className="flex flex-wrap items-center gap-3 rounded-2xl border border-emerald-500/30 bg-slate-900/70 px-4 py-3 text-xs text-slate-200">
+          <Badge color="emerald">Pinned cohort</Badge>
+          <span className="font-semibold text-white">{payload?.name ?? "No cohort selected"}</span>
+          <span className="rounded-full bg-slate-800 px-3 py-1">Net eligible ~ {fmtK(netEligible)}</span>
+          <span className="rounded-full bg-slate-800 px-3 py-1" data-testid="dest-email">
+            Email ~{fmtK(destinations.email)}
+          </span>
+          <span className="rounded-full bg-slate-800 px-3 py-1" data-testid="dest-social">
+            Paid social ~{fmtK(destinations.social)}
+          </span>
+          <span className="rounded-full bg-slate-800 px-3 py-1" data-testid="dest-sms">
+            SMS ~{fmtK(destinations.sms)}
+          </span>
+        </div>
+
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 px-4 py-3 text-xs text-slate-200">
+          <div className="flex flex-wrap items-center gap-4">
+            {["step1", "step2", "step3"].map((key) => {
+              const labelMap: Record<StepKey, { title: string; action: string }> = {
+                step1: { title: "Step 1: Read-in & refine", action: "Apply standard exclusions" },
+                step2: { title: "Step 2: QA & readiness", action: "Run checks" },
+                step3: { title: "Step 3: Lock & export", action: "Prepare export" }
+              };
+              const data = labelMap[key as StepKey];
+              return (
+                <div key={key} className="flex items-center gap-2">
+                  <span className="text-slate-400">{data.title}</span>
+                  <button
+                    type="button"
+                    className={`focus-outline rounded-full px-3 py-1 text-xs font-semibold transition ${
+                      stepChecks[key as StepKey]
+                        ? "bg-emerald-500 text-slate-900"
+                        : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+                    }`}
+                    onClick={() => triggerStep(key as StepKey)}
+                  >
+                    {data.action}
+                  </button>
+                  {stepToast[key as StepKey] && (
+                    <span className="rounded-full border border-emerald-400 bg-emerald-500/20 px-2 py-0.5 text-[11px] text-emerald-200">
+                      Done
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {missing && (
+          <div className="rounded-2xl border border-dashed border-slate-800 bg-slate-900/60 p-6 text-center text-sm text-slate-300">
+            <p>No Market Radar export detected.</p>
+            <button
+              type="button"
+              className="mt-3 focus-outline rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-900 hover:bg-emerald-400"
+              onClick={emptyImport}
+            >
+              Import last from Market Radar
+            </button>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+          <aside className="space-y-4 lg:col-span-3">
+            <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+              <header className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-white">From Market Radar</h3>
+                {payload && <Badge color="slate">Read-in</Badge>}
+              </header>
+              {payload ? (
+                <div className="mt-3 space-y-3 text-xs text-slate-200">
+                  <div className="flex flex-wrap gap-2">
+                    {payload.chips.map((chip) => (
+                      <span key={chip} className="rounded-full bg-slate-800 px-3 py-1">{chip}</span>
+                    ))}
+                  </div>
+                  <p className="text-slate-400">
+                    Window: {payload.geoWindow.window} • Grain: {payload.geoWindow.grain}
+                  </p>
+                  <div className="grid gap-2 rounded-xl border border-slate-800 bg-slate-900/80 p-3 text-xs">
+                    <div className="flex items-center justify-between">
+                      <span className="text-slate-400">Opportunity score</span>
+                      <span className="font-semibold text-emerald-200">{Math.round(payload.kpis.opportunityScore * 100)}%</span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-slate-400">Reachable</span>
+                      <span className="font-semibold">{fmtK(payload.kpis.reachable)}</span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-slate-400">Expected CVR</span>
+                      <span className="font-semibold">{payload.kpis.expectedCVR[0]}–{payload.kpis.expectedCVR[1]}%</span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-slate-400">Payback</span>
+                      <span className="font-semibold">~{payload.kpis.paybackMonths} mo</span>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <p className="mt-3 text-xs text-slate-400">No cohort selected yet.</p>
+              )}
+            </section>
+
+            <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+              <h3 className="text-sm font-semibold text-white">Lineage</h3>
+              <p className="mt-2 text-xs text-slate-400">Diff vs read-in</p>
+              <button
+                type="button"
+                className="mt-3 focus-outline rounded-full bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-200 hover:bg-slate-700"
+                onClick={() => setLineageOpen((prev) => !prev)}
+              >
+                {lineageOpen ? "Hide details" : "Show details"}
+              </button>
+              {lineageOpen && (
+                <div className="mt-3 space-y-2 text-xs text-slate-200">
+                  <p>Include added: {diff.includeAdded.join(", ") || "None"}</p>
+                  <p>Include removed: {diff.includeRemoved.join(", ") || "None"}</p>
+                  <p>Exclude added: {diff.excludeAdded.join(", ") || "None"}</p>
+                  <p>Exclude removed: {diff.excludeRemoved.join(", ") || "None"}</p>
+                </div>
+              )}
+              {!lineageOpen && lineageSummary && (
+                <p className="mt-3 text-xs text-emerald-200">{lineageSummary}</p>
+              )}
+            </section>
+          </aside>
+
+          <section className="space-y-4 lg:col-span-6">
+            <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+              <header className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-white">Rules builder</h3>
+                <button
+                  type="button"
+                  className="text-xs text-emerald-300 underline"
+                  onClick={() => setIncludeLogic((prev) => (prev === "AND" ? "OR" : "AND"))}
+                >
+                  Toggle logic ({includeLogic})
+                </button>
+              </header>
+              <div className="mt-3 grid gap-4 md:grid-cols-2">
+                <div>
+                  <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Include ({includeLogic})</h4>
+                  <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                    {includeChips.map((chip) => (
+                      <button
+                        key={chip}
+                        type="button"
+                        className="rounded-full bg-emerald-500/20 px-3 py-1 text-emerald-200"
+                        onClick={() => setIncludeChips((prev) => prev.filter((item) => item !== chip))}
+                      >
+                        {chip} ×
+                      </button>
+                    ))}
+                  </div>
+                  <div className="mt-2 flex items-center gap-2">
+                    <input
+                      value={includeInput}
+                      onChange={(event) => setIncludeInput(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                          event.preventDefault();
+                          addChip("include");
+                        }
+                      }}
+                      placeholder="Add include"
+                      className="focus-outline w-full rounded-full border border-slate-800 bg-slate-900 px-3 py-1 text-xs"
+                    />
+                    <button
+                      type="button"
+                      className="focus-outline rounded-full bg-emerald-500 px-3 py-1 text-xs font-semibold text-slate-900"
+                      onClick={() => addChip("include")}
+                    >
+                      Add
+                    </button>
+                  </div>
+                </div>
+                <div>
+                  <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Exclude</h4>
+                  <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                    {excludeChips.map((chip) => (
+                      <button
+                        key={chip}
+                        type="button"
+                        className="rounded-full bg-slate-800 px-3 py-1 text-slate-200"
+                        onClick={() => setExcludeChips((prev) => prev.filter((item) => item !== chip))}
+                      >
+                        {chip} ×
+                      </button>
+                    ))}
+                  </div>
+                  <div className="mt-2 flex items-center gap-2">
+                    <input
+                      value={excludeInput}
+                      onChange={(event) => setExcludeInput(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                          event.preventDefault();
+                          addChip("exclude");
+                        }
+                      }}
+                      placeholder="Add exclude"
+                      className="focus-outline w-full rounded-full border border-slate-800 bg-slate-900 px-3 py-1 text-xs"
+                    />
+                    <button
+                      type="button"
+                      className="focus-outline rounded-full bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-200"
+                      onClick={() => addChip("exclude")}
+                    >
+                      Add
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div className="mt-4 rounded-xl border border-slate-800 bg-slate-900/80 p-3 text-xs text-slate-300">
+                Net eligible preview: <span className="font-semibold text-white" data-testid="net-eligible">{fmtK(netEligible)}</span>
+                {payload && (
+                  <span className="ml-2 text-emerald-200">{deltaLabel} vs read-in</span>
+                )}
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+                <h3 className="text-sm font-semibold text-white">ID graph & dedup</h3>
+                <div className="mt-3 flex gap-2" role="radiogroup" aria-label="Dedup grain">
+                  <button
+                    type="button"
+                    aria-label="Dedup grain household"
+                    className={`focus-outline rounded-full px-3 py-1 text-xs font-semibold transition ${
+                      dedupGrain === "Household"
+                        ? "bg-emerald-500 text-slate-900"
+                        : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+                    }`}
+                    onClick={() => setDedupGrain("Household")}
+                  >
+                    Household
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Dedup grain person"
+                    className={`focus-outline rounded-full px-3 py-1 text-xs font-semibold transition ${
+                      dedupGrain === "Person"
+                        ? "bg-emerald-500 text-slate-900"
+                        : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+                    }`}
+                    onClick={() => setDedupGrain("Person")}
+                  >
+                    Person
+                  </button>
+                </div>
+                <p className="mt-3 text-xs text-slate-400">
+                  Dedup base from read-in reachable {fmtK(baseReach)}. Person grain adds ~6% lift.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+                <h3 className="text-sm font-semibold text-white">Overlap & suppressions</h3>
+                <p className="mt-2 text-xs text-slate-400">
+                  Apply standard suppressions to lower overlap and clear compliance gates.
+                </p>
+                <button
+                  type="button"
+                  className={`mt-3 focus-outline rounded-full px-3 py-1 text-xs font-semibold transition ${
+                    suppressionsApplied
+                      ? "bg-emerald-500 text-slate-900"
+                      : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+                  }`}
+                  onClick={() => setSuppressionsApplied(true)}
+                  disabled={suppressionsApplied}
+                >
+                  {suppressionsApplied ? "Suppressions applied" : "Apply standard suppressions"}
+                </button>
+                <p className="mt-3 text-xs text-slate-300">
+                  Net eligible after suppressions: <span className="font-semibold text-white">{fmtK(netEligible)}</span>
+                </p>
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+                <h3 className="text-sm font-semibold text-white">Test & holdout split</h3>
+                <label htmlFor="holdout" className="mt-2 block text-xs text-slate-300">
+                  Global holdout ({holdout}%)
+                </label>
+                <input
+                  id="holdout"
+                  type="range"
+                  min={5}
+                  max={15}
+                  value={holdout}
+                  aria-label="Holdout slider"
+                  onChange={(event) => setHoldout(Number(event.target.value))}
+                  className="mt-2 w-full"
+                />
+              </div>
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+                <h3 className="text-sm font-semibold text-white">Destinations preview</h3>
+                <div className="mt-3 grid gap-2 text-xs">
+                  <div className="flex items-center justify-between">
+                    <span>Email</span>
+                    <span>~{fmtK(destinations.email)}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Paid social</span>
+                    <span>~{fmtK(destinations.social)}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>SMS</span>
+                    <span>~{fmtK(destinations.sms)}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <aside className="space-y-4 lg:col-span-3">
+            <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+              <h3 className="text-sm font-semibold text-white">QA & readiness</h3>
+              <Meter label="Readiness" value={readinessScore} helper="Target >= 75" />
+              <p className="mt-2 text-xs font-semibold text-white" data-testid="readiness-score">
+                {readinessScore}% ready
+              </p>
+              <div className="mt-3 space-y-2 text-xs">
+                {readinessRows.map((row) => (
+                  <div key={row.label} className="flex items-center justify-between">
+                    <span className="text-slate-300">{row.label}</span>
+                    <span className={row.pass ? "text-emerald-300" : "text-amber-300"}>{row.pass ? "Pass" : "Review"}</span>
+                  </div>
+                ))}
+              </div>
+              <label className="mt-4 flex items-center gap-2 text-xs text-slate-200">
+                <input
+                  type="checkbox"
+                  checked={contactPermissions}
+                  onChange={(event) => setContactPermissions(event.target.checked)}
+                />
+                Contact permissions
+              </label>
+              {!contactPermissions && (
+                <div className="mt-3 rounded-xl border border-amber-400/40 bg-amber-400/10 p-3 text-xs text-amber-200">
+                  <p>Warning: Consent below threshold.</p>
+                  <button
+                    type="button"
+                    className="mt-2 focus-outline rounded-full bg-amber-400 px-3 py-1 text-xs font-semibold text-slate-900"
+                    onClick={() => setContactPermissions(true)}
+                  >
+                    Fix
+                  </button>
+                </div>
+              )}
+            </section>
+
+            <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+              <h3 className="text-sm font-semibold text-white">Governance</h3>
+              {payload ? (
+                <div className="mt-3 space-y-2 text-xs text-slate-300">
+                  <p>Segment ID: {payload.id}</p>
+                  <p>Created: {new Date(payload.createdAt).toLocaleString()}</p>
+                  <p>Version: {payload.version}</p>
+                  <p>Pressure index: {(payload.pressureIndex ?? 0) * 100}%</p>
+                  <p>White space: {(payload.whiteSpace ?? 0) * 100}%</p>
+                </div>
+              ) : (
+                <p className="mt-3 text-xs text-slate-400">Awaiting read-in.</p>
+              )}
+            </section>
+          </aside>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <button className="focus-outline rounded-full bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-slate-700">
+            Validate
+          </button>
+          <button
+            className="focus-outline rounded-full bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-slate-700"
+            onClick={lockCohort}
+          >
+            Lock cohort
+          </button>
+          <button className="focus-outline rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-900 hover:bg-emerald-400">
+            Export…
+          </button>
+          <button className="focus-outline rounded-full bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-slate-700">
+            Send to Campaign Designer
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SegmentStudioWireframe;

--- a/src/__tests__/marketRadar.spec.tsx
+++ b/src/__tests__/marketRadar.spec.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import React from "react";
+import MarketRadarTab from "../marketRadar/MarketRadarTab";
+
+const setup = () => render(<MarketRadarTab />);
+
+describe("MarketRadarTab", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders without crash and shows summary", () => {
+    setup();
+    expect(screen.getByText(/How to use Market Radar/i)).toBeInTheDocument();
+  });
+
+  it("switches to map tab when clicked", () => {
+    setup();
+    const mapTab = screen.getByRole("tab", { name: "Map" });
+    fireEvent.click(mapTab);
+    expect(screen.getByRole("img", { name: /US opportunity map/i })).toBeInTheDocument();
+  });
+
+  it("updates key metrics when selecting a new archetype bubble", async () => {
+    setup();
+    const targetBubble = await screen.findByRole("button", { name: /Hybrid HQs bubble/i });
+    fireEvent.click(targetBubble);
+    await waitFor(() => {
+      expect(screen.getByText("150k")).toBeInTheDocument();
+    });
+  });
+
+  it("toggles more metrics visibility", () => {
+    setup();
+    const toggle = screen.getByRole("button", { name: /More metrics/i });
+    fireEvent.click(toggle);
+    expect(screen.getByText(/ARPU delta/i)).toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(screen.queryByText(/ARPU delta/i)).not.toBeInTheDocument();
+  });
+
+  it("opens competitive drawer with ranked bars", () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: /See all/i }));
+    const drawer = screen.getByRole("dialog", { name: /Competitive landscape/i });
+    const firstEntry = within(drawer).getAllByText(/%/i)[0];
+    expect(firstEntry.textContent).toContain("%");
+    expect(within(drawer).getByText(/Top threat/i)).toBeInTheDocument();
+  });
+
+  it("opens details drawer with micro segments", async () => {
+    setup();
+    fireEvent.click(screen.getAllByRole("button", { name: "View" })[0]);
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: /micro-segments/i })).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Global CS pods/i)).toBeInTheDocument();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,36 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 30%, #f8fafc 100%);
+}
+
+a {
+  color: inherit;
+}
+
+.focus-outline:focus-visible {
+  outline: 3px solid theme('colors.primary.DEFAULT');
+  outline-offset: 2px;
+}
+
+.card {
+  @apply bg-slate-900/80 backdrop-blur rounded-2xl text-slate-50 shadow-soft;
+}
+
+.card-light {
+  @apply bg-white rounded-2xl shadow-lg;
+}
+
+.badge {
+  @apply inline-flex items-center gap-1 rounded-full bg-emerald-500/10 text-emerald-200 px-3 py-1 text-xs font-medium;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
-import MarketRadarTab from "./marketRadar/MarketRadarTab";
+import AcquisitionDemoApp from "./AcquisitionDemoApp";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <MarketRadarTab />
+    <AcquisitionDemoApp />
   </React.StrictMode>
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import MarketRadarTab from "./marketRadar/MarketRadarTab";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <MarketRadarTab />
+  </React.StrictMode>
+);

--- a/src/marketRadar/MarketRadarTab.tsx
+++ b/src/marketRadar/MarketRadarTab.tsx
@@ -1,0 +1,120 @@
+/**
+ * MarketRadarTab composes the guided Market Radar experience with mock data.
+ */
+import React, { useMemo, useRef, useState } from "react";
+import TopSummary from "./components/TopSummary";
+import CohortBuilder from "./components/CohortBuilder";
+import MarketLensTabs from "./components/MarketLensTabs";
+import CompetitiveStrip from "./components/CompetitiveStrip";
+import ArchetypeCard from "./components/ArchetypeCard";
+import DetailsDrawer from "./components/DetailsDrawer";
+import KeyMetrics from "./components/KeyMetrics";
+import Info from "./components/Info";
+import { archetypes } from "./data/mockData";
+import { PlaybookHandle } from "./components/PlaybookView";
+
+const timeframes = ["6w", "13w", "26w"] as const;
+
+type Timeframe = (typeof timeframes)[number];
+
+const MarketRadarTab: React.FC = () => {
+  const [timeframe, setTimeframe] = useState<Timeframe>("13w");
+  const [selectedId, setSelectedId] = useState<number>(archetypes[0].id);
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const playbookRef = useRef<PlaybookHandle>(null);
+
+  const selectedArchetype = useMemo(
+    () => archetypes.find((item) => item.id === selectedId) ?? archetypes[0],
+    [selectedId]
+  );
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 pb-20 text-slate-50">
+      <div className="sticky top-0 z-30 border-b border-emerald-500/20 bg-slate-950/90 backdrop-blur">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-xl font-semibold text-white">Market Radar</h1>
+            <p className="text-xs text-slate-400">Segment-first growth radar with AI picks</p>
+          </div>
+          <div className="flex items-center gap-2" role="tablist" aria-label="Timeframe">
+            {timeframes.map((option) => (
+              <button
+                key={option}
+                role="tab"
+                aria-selected={timeframe === option}
+                className={
+                  "focus-outline rounded-full px-3 py-1 text-xs font-semibold transition " +
+                  (timeframe === option
+                    ? "bg-emerald-500 text-slate-900"
+                    : "bg-slate-800 text-slate-200 hover:bg-slate-700")
+                }
+                onClick={() => setTimeframe(option)}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <main className="mx-auto max-w-7xl px-6">
+        <TopSummary />
+        <div className="flex items-center justify-end gap-2 text-xs text-slate-400">
+          <span>Last refreshed yesterday</span>
+          <Info
+            title="What is Market Radar?"
+            lines={[
+              "Blends CRM, product, and market signals",
+              "Ranks segments by opportunity score",
+              "Pairs with competitive intelligence"
+            ]}
+          />
+        </div>
+        <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-12">
+          <div className="lg:col-span-3">
+            <CohortBuilder />
+          </div>
+          <div className="flex flex-col gap-6 lg:col-span-6">
+            <MarketLensTabs
+              items={archetypes}
+              selectedId={selectedId}
+              onSelect={(item) => setSelectedId(item.id)}
+              playbookRef={playbookRef}
+            />
+            <CompetitiveStrip selectedIndex={archetypes.findIndex((item) => item.id === selectedId)} />
+            <section aria-label="AI Picks" className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-white">AI Picks</h3>
+                <span className="text-xs text-slate-400">Powered by the Market Lens</span>
+              </div>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                {archetypes.map((item) => (
+                  <ArchetypeCard
+                    key={item.id}
+                    item={item}
+                    selected={item.id === selectedId}
+                    onSelect={(chosen) => {
+                      setSelectedId(chosen.id);
+                    }}
+                    onViewDetails={(chosen) => {
+                      setSelectedId(chosen.id);
+                      setDetailsOpen(true);
+                    }}
+                    onAddToPlan={(chosen) => playbookRef.current?.addToPlan(chosen)}
+                  />
+                ))}
+              </div>
+            </section>
+          </div>
+          <div className="lg:col-span-3">
+            <KeyMetrics archetype={selectedArchetype} />
+          </div>
+        </div>
+      </main>
+
+      <DetailsDrawer open={detailsOpen} onClose={() => setDetailsOpen(false)} archetype={selectedArchetype} />
+    </div>
+  );
+};
+
+export default MarketRadarTab;

--- a/src/marketRadar/MarketRadarWireframe.tsx
+++ b/src/marketRadar/MarketRadarWireframe.tsx
@@ -1,9 +1,9 @@
 /**
- * MarketRadarTab composes the guided Market Radar experience with mock data.
+ * MarketRadarWireframe composes the guided Market Radar experience with mock data and export wiring.
  */
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import TopSummary from "./components/TopSummary";
-import CohortBuilder from "./components/CohortBuilder";
+import CohortBuilder, { filterGroups } from "./components/CohortBuilder";
 import MarketLensTabs from "./components/MarketLensTabs";
 import CompetitiveStrip from "./components/CompetitiveStrip";
 import ArchetypeCard from "./components/ArchetypeCard";
@@ -12,21 +12,111 @@ import KeyMetrics from "./components/KeyMetrics";
 import Info from "./components/Info";
 import { archetypes } from "./data/mockData";
 import { PlaybookHandle } from "./components/PlaybookView";
+import { SegmentPayload, saveOne } from "../storage";
 
 const timeframes = ["6w", "13w", "26w"] as const;
 
 type Timeframe = (typeof timeframes)[number];
 
-const MarketRadarTab: React.FC = () => {
+const baseGeoWindow = { geo: "DFW-07, DFW-12", grain: "ZIP clusters" };
+
+const initialFilters = () => {
+  const seed: Record<string, string[]> = {};
+  filterGroups.forEach((group) => {
+    seed[group.title] = [];
+  });
+  seed.Stage = ["Enterprise"];
+  seed.Motion = ["Product-led"];
+  seed.Team = ["Remote"];
+  seed.Pain = ["Support"];
+  seed.Stack = ["Salesforce"];
+  seed.Signals = ["Expansion"];
+  return seed;
+};
+
+const MarketRadarWireframe: React.FC<{ onExport?: (payload: SegmentPayload) => void }> = ({ onExport }) => {
   const [timeframe, setTimeframe] = useState<Timeframe>("13w");
   const [selectedId, setSelectedId] = useState<number>(archetypes[0].id);
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const [filters, setFilters] = useState<Record<string, string[]>>(initialFilters);
+  const [toastVisible, setToastVisible] = useState(false);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const playbookRef = useRef<PlaybookHandle>(null);
+  const selectedCohortName = "AIPIC cohort";
+
+  useEffect(() => {
+    return () => {
+      if (toastTimer.current) {
+        clearTimeout(toastTimer.current);
+      }
+    };
+  }, []);
 
   const selectedArchetype = useMemo(
     () => archetypes.find((item) => item.id === selectedId) ?? archetypes[0],
     [selectedId]
   );
+
+  const selectedChips = useMemo(() => {
+    const chips: string[] = [];
+    Object.values(filters).forEach((list) => {
+      chips.push(...list);
+    });
+    return chips;
+  }, [filters]);
+
+  const geoWindow = useMemo(
+    () => ({ ...baseGeoWindow, window: timeframe }),
+    [timeframe]
+  );
+
+  const kpis = useMemo(
+    () => ({
+      opportunityScore: 0.58,
+      reachable: 210000,
+      expectedCVR: [0.9, 1.2] as [number, number],
+      paybackMonths: 8.5
+    }),
+    []
+  );
+
+  const rivals = ["FirmWare"];
+  const pressureIndex = 0.37;
+  const whiteSpace = 0.31;
+
+  const canExport = selectedCohortName.trim().length > 0 && selectedChips.length > 0;
+
+  const triggerToast = () => {
+    if (toastTimer.current) {
+      clearTimeout(toastTimer.current);
+    }
+    setToastVisible(true);
+    toastTimer.current = setTimeout(() => setToastVisible(false), 2000);
+  };
+
+  const handleExport = () => {
+    if (!canExport) {
+      return;
+    }
+    const payload: SegmentPayload = {
+      id: `seg_${Date.now()}`,
+      name: selectedCohortName,
+      label: "Radar export",
+      chips: selectedChips,
+      filters,
+      geoWindow,
+      kpis,
+      rivals,
+      pressureIndex,
+      whiteSpace,
+      createdAt: new Date().toISOString(),
+      version: 1
+    };
+    saveOne(payload);
+    onExport?.(payload);
+    triggerToast();
+    window.location.hash = `#/studio/${payload.id}`;
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 pb-20 text-slate-50">
@@ -72,7 +162,7 @@ const MarketRadarTab: React.FC = () => {
         </div>
         <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-12">
           <div className="lg:col-span-3">
-            <CohortBuilder />
+            <CohortBuilder selected={filters} onSelectedChange={setFilters} />
           </div>
           <div className="flex flex-col gap-6 lg:col-span-6">
             <MarketLensTabs
@@ -86,6 +176,13 @@ const MarketRadarTab: React.FC = () => {
               <div className="flex items-center justify-between">
                 <h3 className="text-lg font-semibold text-white">AI Picks</h3>
                 <span className="text-xs text-slate-400">Powered by the Market Lens</span>
+              </div>
+              <div
+                className="flex items-center justify-between text-xs text-slate-300"
+                data-testid="market-selected-chips"
+              >
+                <span>Selected chips</span>
+                <span className="text-emerald-200">{selectedChips.join(", ") || "None"}</span>
               </div>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 {archetypes.map((item) => (
@@ -104,6 +201,28 @@ const MarketRadarTab: React.FC = () => {
                   />
                 ))}
               </div>
+              <div className="flex flex-col gap-2 rounded-2xl border border-emerald-500/40 bg-slate-900/70 p-4">
+                <button
+                  type="button"
+                  className="focus-outline rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-300"
+                  onClick={handleExport}
+                  disabled={!canExport}
+                  data-testid="export-market-to-studio"
+                >
+                  Export to Segment Studio
+                </button>
+                {!canExport && (
+                  <span className="text-xs text-slate-400">Select at least one chip to enable export.</span>
+                )}
+                {toastVisible && (
+                  <span
+                    className="inline-flex items-center justify-center rounded-full border border-emerald-400 bg-emerald-500/20 px-3 py-1 text-xs font-semibold text-emerald-200"
+                    data-testid="export-toast"
+                  >
+                    Exported to Segment Studio
+                  </span>
+                )}
+              </div>
             </section>
           </div>
           <div className="lg:col-span-3">
@@ -117,4 +236,4 @@ const MarketRadarTab: React.FC = () => {
   );
 };
 
-export default MarketRadarTab;
+export default MarketRadarWireframe;

--- a/src/marketRadar/components/ArchetypeCard.tsx
+++ b/src/marketRadar/components/ArchetypeCard.tsx
@@ -1,0 +1,92 @@
+/**
+ * Archetype card summarises an AI pick with actions for selection, details, and plan add.
+ */
+import React from "react";
+import { Archetype } from "../data/mockData";
+import { Badge, Meter } from "./atoms";
+
+export type ArchetypeCardProps = {
+  item: Archetype;
+  selected: boolean;
+  onSelect: (item: Archetype) => void;
+  onViewDetails: (item: Archetype) => void;
+  onAddToPlan: (item: Archetype) => void;
+};
+
+const confColor: Record<Archetype["conf"], string> = {
+  high: "bg-emerald-500/30 text-emerald-100",
+  med: "bg-amber-500/30 text-amber-100",
+  low: "bg-slate-500/30 text-slate-100"
+};
+
+const ArchetypeCard: React.FC<ArchetypeCardProps> = ({ item, selected, onSelect, onViewDetails, onAddToPlan }) => {
+  return (
+    <article
+      className={`card flex flex-col gap-4 border ${selected ? "border-emerald-400" : "border-slate-800"} p-4 transition hover:border-emerald-400/80`}
+      aria-label={`${item.title} archetype card`}
+    >
+      <header className="flex items-start justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+          <p className="text-xs text-slate-400">Rival focus: {item.rival}</p>
+        </div>
+        <Badge className="bg-emerald-500/30 text-emerald-100">AI pick</Badge>
+      </header>
+      <Meter label="Opportunity score" value={item.score} helper={`Confidence ${item.conf}`} />
+      <div className="flex flex-wrap gap-2 text-xs text-slate-200">
+        <Badge color="slate">CVR {item.cvr}</Badge>
+        <Badge color="slate">Payback {item.payback}</Badge>
+        <span className={`inline-flex items-center rounded-full px-3 py-1 ${confColor[item.conf]} text-xs font-semibold`}>
+          Conf {item.conf}
+        </span>
+      </div>
+      <div className="space-y-2 rounded-xl border border-slate-800 bg-slate-900/60 p-3 text-xs text-slate-200">
+        <p className="font-semibold text-slate-100">Motivations to switch</p>
+        <ul className="list-disc space-y-1 pl-4">
+          {item.drivers.slice(0, 2).map((driver) => (
+            <li key={driver}>{driver}</li>
+          ))}
+        </ul>
+      </div>
+      <div className="grid grid-cols-2 gap-3 text-xs text-slate-200">
+        <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+          <p className="font-semibold text-white">{item.rival}</p>
+          <p className="text-[11px] text-slate-400">{item.rivalNote}</p>
+        </div>
+        <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3">
+          <p className="text-[11px] uppercase tracking-wide text-emerald-200">Gaps to exploit</p>
+          <ul className="mt-1 space-y-1 text-emerald-100">
+            {item.gaps.slice(0, 2).map((gap) => (
+              <li key={gap}>• {gap}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="focus-outline rounded-full bg-slate-800 px-4 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-700"
+          onClick={() => onViewDetails(item)}
+        >
+          View
+        </button>
+        <button
+          type="button"
+          className="focus-outline rounded-full bg-emerald-500 px-4 py-2 text-xs font-semibold text-slate-900 transition hover:bg-emerald-400"
+          onClick={() => onSelect(item)}
+        >
+          Select
+        </button>
+        <button
+          type="button"
+          className="focus-outline rounded-full border border-emerald-500 px-4 py-2 text-xs font-semibold text-emerald-200 transition hover:bg-emerald-500/20"
+          onClick={() => onAddToPlan(item)}
+        >
+          Add to plan
+        </button>
+      </div>
+    </article>
+  );
+};
+
+export default ArchetypeCard;

--- a/src/marketRadar/components/CohortBuilder.tsx
+++ b/src/marketRadar/components/CohortBuilder.tsx
@@ -1,0 +1,134 @@
+/**
+ * Cohort Builder provides framework chips and a plain-English prompt to define the target audience.
+ */
+import React, { useMemo, useState } from "react";
+import { Badge, SectionTitle } from "./atoms";
+
+const filterGroups: { title: string; options: string[] }[] = [
+  { title: "Stage", options: ["Seed", "Series A", "Series B", "Scaleup", "Enterprise"] },
+  { title: "Motion", options: ["Product-led", "Sales-led", "Hybrid", "Channel", "Self-serve"] },
+  { title: "Team", options: ["Remote", "Hybrid", "Field", "Retail", "Agency"] },
+  { title: "Pain", options: ["Onboarding", "Compliance", "Support", "Payments", "Analytics"] },
+  { title: "Stack", options: ["Salesforce", "HubSpot", "Zendesk", "Slack", "Workday"] },
+  { title: "Signals", options: ["Hiring", "Funding", "Expansion", "Downsizing", "Tool churn"] }
+];
+
+const CohortBuilder: React.FC = () => {
+  const [ask, setAsk] = useState("");
+  const [submitted, setSubmitted] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Record<string, Set<string>>>(() => {
+    const initial: Record<string, Set<string>> = {};
+    filterGroups.forEach((group) => {
+      initial[group.title] = new Set();
+    });
+    return initial;
+  });
+
+  const toggleOption = (group: string, option: string) => {
+    setSelected((prev) => {
+      const groupSet = new Set(prev[group]);
+      if (groupSet.has(option)) {
+        groupSet.delete(option);
+      } else {
+        groupSet.add(option);
+      }
+      return { ...prev, [group]: groupSet };
+    });
+  };
+
+  const summary = useMemo(() => {
+    const parts: string[] = [];
+    Object.entries(selected).forEach(([group, values]) => {
+      if (values.size > 0) {
+        parts.push(`${group}: ${Array.from(values).join(", ")}`);
+      }
+    });
+    return parts.join(" • ");
+  }, [selected]);
+
+  return (
+    <aside className="card sticky top-4 flex flex-col gap-6 border border-slate-800 p-6" aria-label="Cohort Builder">
+      <SectionTitle
+        title="Cohort Builder"
+        subtitle="Stack criteria or ask the Radar to translate"
+        action={<Badge color="slate">Beta</Badge>}
+      />
+
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (ask.trim().length > 0) {
+            setSubmitted(`Translated to cohort criteria: "${ask.trim()}"`);
+            setAsk("");
+          }
+        }}
+        className="flex flex-col gap-2"
+      >
+        <label htmlFor="ask-input" className="text-sm font-semibold text-slate-200">
+          Ask the Radar
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="ask-input"
+            value={ask}
+            onChange={(event) => setAsk(event.target.value)}
+            placeholder="e.g. Companies expanding remote success pods"
+            className="focus-outline w-full rounded-xl border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500"
+          />
+          <button
+            type="submit"
+            className="focus-outline rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-emerald-400"
+          >
+            Ask
+          </button>
+        </div>
+        {submitted && <p className="text-xs text-emerald-300">{submitted}</p>}
+      </form>
+
+      <div className="space-y-5" aria-label="Framework chips">
+        {filterGroups.map((group) => (
+          <section key={group.title} className="space-y-3">
+            <header className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-slate-200">{group.title}</h3>
+              {selected[group.title].size > 0 && (
+                <span className="text-xs text-emerald-300">
+                  {selected[group.title].size} selected
+                </span>
+              )}
+            </header>
+            <div className="flex flex-wrap gap-2">
+              {group.options.map((option) => {
+                const isActive = selected[group.title].has(option);
+                return (
+                  <button
+                    type="button"
+                    key={option}
+                    onClick={() => toggleOption(group.title, option)}
+                    className={
+                      "focus-outline rounded-full border px-3 py-1 text-xs font-semibold transition" +
+                      (isActive
+                        ? " border-emerald-400 bg-emerald-500/20 text-emerald-200"
+                        : " border-slate-700 bg-slate-800/60 text-slate-300 hover:border-emerald-500/70 hover:text-emerald-200")
+                    }
+                    aria-pressed={isActive}
+                  >
+                    {option}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      {summary && (
+        <div className="rounded-2xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-xs text-emerald-100">
+          <p className="font-semibold uppercase tracking-wide text-emerald-200">Selected criteria</p>
+          <p className="mt-1 text-slate-100">{summary}</p>
+        </div>
+      )}
+    </aside>
+  );
+};
+
+export default CohortBuilder;

--- a/src/marketRadar/components/CompetitiveStrip.tsx
+++ b/src/marketRadar/components/CompetitiveStrip.tsx
@@ -1,0 +1,85 @@
+/**
+ * Competitive strip visualizes rival pressure for the selected archetype and opens a drawer with details.
+ */
+import React, { useMemo, useState } from "react";
+import { competitors, overlap } from "../data/mockData";
+import Drawer from "./Drawer";
+import { Meter } from "./atoms";
+
+export type CompetitiveStripProps = {
+  selectedIndex: number;
+};
+
+const CompetitiveStrip: React.FC<CompetitiveStripProps> = ({ selectedIndex }) => {
+  const [open, setOpen] = useState(false);
+
+  const data = useMemo(() => {
+    const row = overlap[selectedIndex] ?? [];
+    const parsed = row.map((value, index) => ({
+      name: competitors[index],
+      value: parseInt(value.replace("%", ""), 10)
+    }));
+    parsed.sort((a, b) => b.value - a.value);
+    const top = parsed[0];
+    const second = parsed[1];
+    const pressure = top ? top.value : 0;
+    const whiteSpace = 100 - ((top?.value ?? 0) + (second?.value ?? 0));
+    return { parsed, top, pressure, whiteSpace };
+  }, [selectedIndex]);
+
+  return (
+    <section className="card mt-6 flex flex-col gap-4 border border-slate-800 p-4" aria-label="Competitive strip">
+      <header className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Competitive strip</h3>
+        <button
+          className="focus-outline rounded-full bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-200 hover:bg-slate-700"
+          onClick={() => setOpen(true)}
+        >
+          See all
+        </button>
+      </header>
+      <div className="grid grid-cols-3 gap-4 text-xs text-slate-200">
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-3">
+          <p className="text-[10px] uppercase tracking-wide text-slate-400">Top rival</p>
+          <p className="mt-1 text-base font-semibold text-white">{data.top?.name ?? "N/A"}</p>
+          <p className="text-xs text-emerald-300">Overlap {data.top?.value ?? 0}%</p>
+        </div>
+        <div className="col-span-1">
+          <Meter label="Pressure index" value={data.pressure} helper="0=blue ocean, 100=full heat" />
+        </div>
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-3">
+          <p className="text-[10px] uppercase tracking-wide text-slate-400">White space</p>
+          <p className="mt-1 text-base font-semibold text-emerald-200">{Math.max(data.whiteSpace, 0)}%</p>
+          <p className="text-xs text-slate-400">Uncontested vs top 2 rivals</p>
+        </div>
+      </div>
+      <Drawer open={open} onClose={() => setOpen(false)} title="Competitive landscape">
+        <p className="text-sm text-slate-300">
+          Overlap shows the percent of your cohort that currently leans toward each rival.
+        </p>
+        <div className="mt-4 space-y-3">
+          {data.parsed.map((entry, index) => (
+            <div key={entry.name} className="space-y-1">
+              <div className="flex items-center justify-between text-xs text-slate-200">
+                <span className="font-semibold text-white">{entry.name}</span>
+                <span>{entry.value}%</span>
+              </div>
+              <div className="h-2 w-full rounded-full bg-slate-800">
+                <div
+                  className="h-2 rounded-full bg-gradient-to-r from-emerald-500 to-emerald-300"
+                  style={{ width: `${entry.value}%` }}
+                  aria-label={`${entry.name} overlap ${entry.value}%`}
+                />
+              </div>
+              {index === 0 && (
+                <p className="text-[11px] text-emerald-300">Top threat - focus counter positioning</p>
+              )}
+            </div>
+          ))}
+        </div>
+      </Drawer>
+    </section>
+  );
+};
+
+export default CompetitiveStrip;

--- a/src/marketRadar/components/DetailsDrawer.tsx
+++ b/src/marketRadar/components/DetailsDrawer.tsx
@@ -1,0 +1,65 @@
+/**
+ * Details drawer reveals micro-segments for the selected archetype.
+ */
+import React from "react";
+import { Archetype, microSegments } from "../data/mockData";
+import Drawer from "./Drawer";
+import { Badge } from "./atoms";
+
+type DetailsDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  archetype: Archetype | null;
+};
+
+const DetailsDrawer: React.FC<DetailsDrawerProps> = ({ open, onClose, archetype }) => {
+  const segments = archetype ? microSegments[archetype.id] ?? [] : [];
+
+  return (
+    <Drawer open={open} onClose={onClose} title={archetype ? `${archetype.title} micro-segments` : "Segment details"}>
+      {archetype ? (
+        <div className="space-y-4">
+          {segments.map((segment) => (
+            <div
+              key={segment.title}
+              className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-100"
+            >
+              <header className="flex items-start justify-between gap-2">
+                <h4 className="text-base font-semibold text-white">{segment.title}</h4>
+                <Badge color="emerald">{segment.conf}</Badge>
+              </header>
+              <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-200">
+                <div>
+                  <dt className="text-slate-400">Segment size</dt>
+                  <dd className="font-semibold">{segment.size}</dd>
+                </div>
+                <div>
+                  <dt className="text-slate-400">Reachable now</dt>
+                  <dd className="font-semibold">{segment.reach}</dd>
+                </div>
+                <div>
+                  <dt className="text-slate-400">Expected CVR</dt>
+                  <dd className="font-semibold">{segment.cvr}</dd>
+                </div>
+                <div>
+                  <dt className="text-slate-400">Payback</dt>
+                  <dd className="font-semibold">{segment.payback}</dd>
+                </div>
+              </dl>
+              <p className="mt-3 text-xs text-slate-300">
+                <span className="font-semibold text-emerald-200">Why here?</span> {segment.why}
+              </p>
+            </div>
+          ))}
+          {segments.length === 0 && (
+            <p className="text-sm text-slate-300">No micro-segments mapped yet.</p>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-slate-300">Select an archetype to view details.</p>
+      )}
+    </Drawer>
+  );
+};
+
+export default DetailsDrawer;

--- a/src/marketRadar/components/Drawer.tsx
+++ b/src/marketRadar/components/Drawer.tsx
@@ -1,0 +1,93 @@
+/**
+ * Generic sliding drawer that appears on either left or right side with a focus trap.
+ */
+import React, { useEffect, useRef } from "react";
+import clsx from "clsx";
+
+type DrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  side?: "right" | "left";
+  children: React.ReactNode;
+};
+
+const Drawer: React.FC<DrawerProps> = ({ open, onClose, title, side = "right", children }) => {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    const focusable = panelRef.current?.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    focusable?.[0]?.focus();
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+      if (event.key === "Tab" && focusable && focusable.length > 0) {
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  return (
+    <div
+      className={clsx(
+        "fixed inset-0 z-40 flex transition",
+        open ? "pointer-events-auto" : "pointer-events-none"
+      )}
+      aria-hidden={!open}
+    >
+      <button
+        className={clsx(
+          "flex-1 bg-slate-900/40 transition-opacity",
+          open ? "opacity-100" : "opacity-0"
+        )}
+        onClick={onClose}
+        aria-label="Close drawer backdrop"
+      />
+      <div
+        ref={panelRef}
+        className={clsx(
+          "card flex h-full w-full max-w-md flex-col gap-4 overflow-y-auto border border-slate-800 p-6 text-slate-100 transition-transform",
+          side === "right" ? "ml-auto" : "mr-auto",
+          open ? "translate-x-0" : side === "right" ? "translate-x-full" : "-translate-x-full"
+        )}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+      >
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="text-xl font-semibold text-white">{title}</h3>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="focus-outline rounded-full bg-slate-800 px-3 py-1 text-sm font-semibold text-slate-200 hover:bg-slate-700"
+          >
+            Close
+          </button>
+        </div>
+        <div className="pb-4">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default Drawer;

--- a/src/marketRadar/components/Info.tsx
+++ b/src/marketRadar/components/Info.tsx
@@ -1,0 +1,57 @@
+/**
+ * Info tooltip component providing quick feature guidance.
+ */
+import React, { useId, useState } from "react";
+
+export type InfoProps = {
+  title: string;
+  lines: string[];
+};
+
+const Info: React.FC<InfoProps> = ({ title, lines }) => {
+  const id = useId();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative inline-block text-left">
+      <button
+        type="button"
+        className="focus-outline flex h-6 w-6 items-center justify-center rounded-full border border-emerald-400/60 bg-slate-900 text-emerald-200 shadow-soft transition hover:bg-emerald-500/20"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={id}
+        onClick={() => setOpen((prev) => !prev)}
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+            setOpen(false);
+          }
+        }}
+      >
+        <span className="text-xs font-semibold">i</span>
+      </button>
+      {open && (
+        <div
+          id={id}
+          role="dialog"
+          aria-label={title}
+          className="absolute right-0 z-20 mt-2 w-64 rounded-2xl bg-slate-900 p-4 text-left text-sm text-slate-100 shadow-xl"
+        >
+          <p className="font-semibold text-emerald-200">{title}</p>
+          <ul className="mt-2 space-y-1 text-slate-300">
+            {lines.map((line) => (
+              <li key={line}>• {line}</li>
+            ))}
+          </ul>
+          <button
+            className="mt-3 rounded-full bg-emerald-500 px-3 py-1 text-xs font-semibold text-slate-900 transition hover:bg-emerald-400"
+            onClick={() => setOpen(false)}
+          >
+            Close
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Info;

--- a/src/marketRadar/components/KeyMetrics.tsx
+++ b/src/marketRadar/components/KeyMetrics.tsx
@@ -1,0 +1,55 @@
+/**
+ * Key metrics rail shows top metrics with a toggle for additional ones.
+ */
+import React, { useMemo, useState } from "react";
+import { Archetype } from "../data/mockData";
+import { Meter, Stat } from "./atoms";
+import { signalStrength } from "../utils";
+
+type KeyMetricsProps = {
+  archetype: Archetype;
+};
+
+const KeyMetrics: React.FC<KeyMetricsProps> = ({ archetype }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const extra = useMemo(
+    () => [
+      { label: "ARPU delta", value: "+$38" },
+      { label: "Confidence", value: archetype.conf.toUpperCase() },
+      { label: "Signal strength", value: `${signalStrength(archetype.score)}` }
+    ],
+    [archetype]
+  );
+
+  return (
+    <aside className="card sticky top-4 flex flex-col gap-4 border border-slate-800 p-6" aria-label="Key metrics">
+      <header className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-white">Key metrics</h3>
+        <button
+          type="button"
+          className="focus-outline rounded-full bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-200 hover:bg-slate-700"
+          onClick={() => setExpanded((prev) => !prev)}
+          aria-expanded={expanded}
+        >
+          {expanded ? "Fewer metrics" : "More metrics"}
+        </button>
+      </header>
+      <Meter label="Opportunity score" value={archetype.score} />
+      <div className="grid grid-cols-1 gap-3">
+        <Stat label="Reachable" value={archetype.reachable} />
+        <Stat label="Expected CVR" value={archetype.cvr} />
+        <Stat label="Payback" value={archetype.payback} />
+      </div>
+      {expanded && (
+        <div className="grid grid-cols-1 gap-3">
+          {extra.map((item) => (
+            <Stat key={item.label} label={item.label} value={item.value} />
+          ))}
+        </div>
+      )}
+    </aside>
+  );
+};
+
+export default KeyMetrics;

--- a/src/marketRadar/components/MapViewUS.tsx
+++ b/src/marketRadar/components/MapViewUS.tsx
@@ -1,0 +1,194 @@
+/**
+ * Map view renders a simplified US choropleth using d3-geo for projection.
+ */
+import React, { useMemo, useState } from "react";
+import { geoAlbersUsa, geoPath } from "d3-geo";
+import { usStates } from "../data/mockData";
+
+const LAYERS = [
+  { id: "opportunity", label: "Opportunity" },
+  { id: "weak", label: "Competitor weak" }
+] as const;
+
+type LayerId = (typeof LAYERS)[number]["id"];
+
+type Tooltip = {
+  state: string;
+  value: number;
+  x: number;
+  y: number;
+} | null;
+
+const stateBounds: Record<string, [number, number][]> = {
+  CA: [
+    [-124.4, 32.5],
+    [-114.1, 32.5],
+    [-114.1, 42.0],
+    [-124.4, 42.0]
+  ],
+  TX: [
+    [-106.6, 25.8],
+    [-93.5, 25.8],
+    [-93.5, 36.5],
+    [-106.6, 36.5]
+  ],
+  NY: [
+    [-79.8, 40.5],
+    [-71.8, 40.5],
+    [-71.8, 45.1],
+    [-79.8, 45.1]
+  ],
+  FL: [
+    [-87.6, 24.6],
+    [-80.1, 24.6],
+    [-80.1, 31.0],
+    [-87.6, 31.0]
+  ],
+  IL: [
+    [-91.6, 36.9],
+    [-87.0, 36.9],
+    [-87.0, 42.5],
+    [-91.6, 42.5]
+  ],
+  WA: [
+    [-124.9, 45.5],
+    [-116.9, 45.5],
+    [-116.9, 49.0],
+    [-124.9, 49.0]
+  ],
+  GA: [
+    [-85.6, 30.5],
+    [-80.8, 30.5],
+    [-80.8, 35.0],
+    [-85.6, 35.0]
+  ],
+  NC: [
+    [-84.3, 33.7],
+    [-75.4, 33.7],
+    [-75.4, 36.6],
+    [-84.3, 36.6]
+  ],
+  CO: [
+    [-109.1, 36.9],
+    [-102.0, 36.9],
+    [-102.0, 41.0],
+    [-109.1, 41.0]
+  ],
+  AZ: [
+    [-114.8, 31.3],
+    [-109.0, 31.3],
+    [-109.0, 37.0],
+    [-114.8, 37.0]
+  ]
+};
+
+const MapViewUS: React.FC = () => {
+  const [layer, setLayer] = useState<LayerId>("opportunity");
+  const [tooltip, setTooltip] = useState<Tooltip>(null);
+
+  const projection = useMemo(() => geoAlbersUsa().scale(900).translate([450 / 2, 280 / 2]), []);
+  const path = useMemo(() => geoPath(projection), [projection]);
+
+  const mockLayer = useMemo(() => {
+    if (layer === "opportunity") {
+      return usStates;
+    }
+    return usStates.map((state, index) => ({
+      ...state,
+      value: Math.max(0, Math.min(1, state.value * (index % 2 === 0 ? 0.6 : 1.2)))
+    }));
+  }, [layer]);
+
+  const colorFor = (value: number) => `rgba(16, 185, 129, ${0.35 + value * 0.5})`;
+
+  const features = useMemo(() => {
+    return mockLayer.map((state) => {
+      const coords = stateBounds[state.id] ?? stateBounds.CA;
+      return {
+        type: "Feature" as const,
+        properties: state,
+        geometry: {
+          type: "Polygon" as const,
+          coordinates: [[...coords, coords[0]]]
+        }
+      };
+    });
+  }, [mockLayer]);
+
+  return (
+    <div className="card flex flex-col gap-4 border border-slate-800 p-4">
+      <header className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-white">Map lens</h3>
+        <div className="flex gap-2" role="tablist" aria-label="Map layer toggle">
+          {LAYERS.map((option) => (
+            <button
+              key={option.id}
+              role="tab"
+              aria-selected={layer === option.id}
+              className={
+                "focus-outline rounded-full px-3 py-1 text-xs font-semibold transition " +
+                (layer === option.id
+                  ? "bg-emerald-500 text-slate-900"
+                  : "bg-slate-800 text-slate-300 hover:bg-slate-700")
+              }
+              onClick={() => setLayer(option.id)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </header>
+      <svg
+        viewBox="0 0 450 280"
+        className="w-full rounded-2xl border border-slate-800 bg-slate-900/80"
+        role="img"
+        aria-label="US opportunity map"
+      >
+        {features.map((feature) => (
+          <path
+            key={feature.properties.id}
+            d={path(feature as never) ?? ""}
+            fill={colorFor(feature.properties.value)}
+            stroke="#0f172a"
+            strokeWidth={1}
+            onClick={(event) => {
+              const bounds = (event.target as SVGPathElement).getBoundingClientRect();
+              setTooltip({
+                state: feature.properties.name,
+                value: feature.properties.value,
+                x: bounds.x + bounds.width / 2,
+                y: bounds.y
+              });
+            }}
+            className="cursor-pointer transition hover:fill-emerald-400/80"
+          >
+            <title>{`${feature.properties.name}: ${(feature.properties.value * 100).toFixed(0)} index`}</title>
+          </path>
+        ))}
+      </svg>
+      {tooltip && (
+        <div
+          className="pointer-events-auto rounded-xl border border-emerald-400/40 bg-slate-900/95 px-3 py-2 text-xs text-slate-100 shadow-lg"
+          style={{
+            position: "fixed",
+            left: tooltip.x,
+            top: tooltip.y - 8,
+            transform: "translate(-50%, -100%)"
+          }}
+        >
+          <p className="font-semibold text-emerald-200">{tooltip.state}</p>
+          <p>Index: {(tooltip.value * 100).toFixed(0)}</p>
+          <button
+            type="button"
+            className="mt-2 rounded-full bg-emerald-500 px-2 py-1 text-[10px] font-semibold text-slate-900"
+            onClick={() => setTooltip(null)}
+          >
+            Close
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MapViewUS;

--- a/src/marketRadar/components/MarketLensTabs.tsx
+++ b/src/marketRadar/components/MarketLensTabs.tsx
@@ -1,0 +1,77 @@
+/**
+ * Market lens orchestrates Matrix, Map, and Playbook tabs with accessible tab controls.
+ */
+import React, { useMemo, useState } from "react";
+import { Archetype } from "../data/mockData";
+import MatrixView from "./MatrixView";
+import MapViewUS from "./MapViewUS";
+import PlaybookView, { PlaybookHandle } from "./PlaybookView";
+
+const tabs = [
+  { id: "matrix", label: "Matrix" },
+  { id: "map", label: "Map" },
+  { id: "playbook", label: "Playbook" }
+] as const;
+
+type TabId = (typeof tabs)[number]["id"];
+
+type MarketLensTabsProps = {
+  items: Archetype[];
+  selectedId: number;
+  onSelect: (item: Archetype) => void;
+  playbookRef: React.RefObject<PlaybookHandle>;
+};
+
+const MarketLensTabs: React.FC<MarketLensTabsProps> = ({ items, selectedId, onSelect, playbookRef }) => {
+  const [activeTab, setActiveTab] = useState<TabId>("matrix");
+
+  const selected = useMemo(() => items.find((item) => item.id === selectedId) ?? items[0], [items, selectedId]);
+
+  return (
+    <section className="flex flex-col gap-4" aria-label="Market lens">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <h2 className="text-2xl font-semibold text-white">Market lens</h2>
+          <span className="rounded-full bg-emerald-500/20 px-3 py-1 text-xs font-semibold uppercase text-emerald-200">
+            Tri-lens
+          </span>
+        </div>
+        <div role="tablist" aria-label="Market lens tabs" className="flex gap-2">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              role="tab"
+              type="button"
+              aria-selected={activeTab === tab.id}
+              className={
+                "focus-outline rounded-full px-4 py-2 text-sm font-semibold transition " +
+                (activeTab === tab.id
+                  ? "bg-emerald-500 text-slate-900"
+                  : "bg-slate-800 text-slate-200 hover:bg-slate-700")
+              }
+              onClick={() => setActiveTab(tab.id)}
+              onKeyDown={(event) => {
+                if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+                  event.preventDefault();
+                  const idx = tabs.findIndex((t) => t.id === activeTab);
+                  const dir = event.key === "ArrowRight" ? 1 : -1;
+                  const next = (idx + dir + tabs.length) % tabs.length;
+                  setActiveTab(tabs[next].id);
+                }
+              }}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-4">
+        {activeTab === "matrix" && <MatrixView items={items} selectedId={selectedId} onSelect={onSelect} />}
+        {activeTab === "map" && <MapViewUS />}
+        {activeTab === "playbook" && <PlaybookView ref={playbookRef} selected={selected ?? null} />}
+      </div>
+    </section>
+  );
+};
+
+export default MarketLensTabs;

--- a/src/marketRadar/components/MatrixView.tsx
+++ b/src/marketRadar/components/MatrixView.tsx
@@ -1,0 +1,171 @@
+/**
+ * Matrix view renders an accessible bubble chart comparing CVR and payback.
+ */
+import React, { useMemo, useRef, useState } from "react";
+import { Archetype } from "../data/mockData";
+import { midRangePercent, midMonths, reachK } from "../utils";
+
+export type MatrixViewProps = {
+  items: Archetype[];
+  selectedId: number;
+  onSelect: (item: Archetype) => void;
+};
+
+type HoverState = {
+  item: Archetype;
+  x: number;
+  y: number;
+} | null;
+
+const MatrixView: React.FC<MatrixViewProps> = ({ items, selectedId, onSelect }) => {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [hovered, setHovered] = useState<HoverState>(null);
+
+  const derived = useMemo(() => {
+    const mapped = items.map((item) => ({
+      item,
+      x: midRangePercent(item.cvr),
+      y: midMonths(item.payback),
+      r: reachK(item.reachable)
+    }));
+    const xExtent = [
+      Math.min(...mapped.map((d) => d.x)) - 0.2,
+      Math.max(...mapped.map((d) => d.x)) + 0.2
+    ];
+    const yExtent = [
+      Math.min(...mapped.map((d) => d.y)) - 0.2,
+      Math.max(...mapped.map((d) => d.y)) + 0.2
+    ];
+    const rExtent = [Math.min(...mapped.map((d) => d.r)), Math.max(...mapped.map((d) => d.r))];
+    return { mapped, xExtent, yExtent, rExtent };
+  }, [items]);
+
+  const width = 520;
+  const height = 360;
+
+  const scaleX = (value: number) => {
+    const [min, max] = derived.xExtent;
+    return ((value - min) / (max - min)) * (width - 80) + 60;
+  };
+
+  const scaleY = (value: number) => {
+    const [min, max] = derived.yExtent;
+    return height - (((value - min) / (max - min)) * (height - 80) + 40);
+  };
+
+  const scaleR = (value: number) => {
+    const [min, max] = derived.rExtent;
+    if (max === min) return 28;
+    const normalized = (value - min) / (max - min);
+    return 20 + normalized * 24;
+  };
+
+  return (
+    <div className="relative">
+      <svg
+        ref={svgRef}
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        role="group"
+        aria-label="Market lens matrix"
+        className="w-full rounded-3xl bg-gradient-to-br from-slate-900 to-slate-900/60 shadow-soft"
+      >
+        <defs>
+          <linearGradient id="bubbleGradient" x1="0" x2="1" y1="0" y2="1">
+            <stop offset="0%" stopColor="#34d399" stopOpacity={0.9} />
+            <stop offset="100%" stopColor="#10b981" stopOpacity={0.8} />
+          </linearGradient>
+        </defs>
+        <g className="text-slate-500" fontSize={12}>
+          <line x1={60} x2={width - 20} y1={height - 40} y2={height - 40} stroke="#1f2937" />
+          <line x1={60} x2={60} y1={40} y2={height - 20} stroke="#1f2937" />
+          <text x={width / 2} y={height - 12} textAnchor="middle" fill="#94a3b8">
+            Expected CVR (%)
+          </text>
+          <text x={12} y={height / 2} transform={`rotate(-90 12 ${height / 2})`} fill="#94a3b8">
+            Payback speed (faster up)
+          </text>
+        </g>
+
+        {derived.mapped.map(({ item, x, y, r, score }) => {
+          const isSelected = item.id === selectedId;
+          return (
+            <g
+              key={item.id}
+              transform={`translate(${scaleX(x)}, ${scaleY(y)})`}
+              className="cursor-pointer focus:outline-none"
+              tabIndex={0}
+              role="button"
+              aria-label={`${item.title} bubble`}
+              aria-pressed={isSelected}
+              onClick={() => onSelect(item)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onSelect(item);
+                }
+              }}
+              onMouseEnter={(event) => {
+                const rect = svgRef.current?.getBoundingClientRect();
+                setHovered({
+                  item,
+                  x: event.clientX - (rect?.left ?? 0),
+                  y: event.clientY - (rect?.top ?? 0)
+                });
+              }}
+              onMouseLeave={() => setHovered(null)}
+              onFocus={(event) => {
+                const rect = svgRef.current?.getBoundingClientRect();
+                setHovered({
+                  item,
+                  x: scaleX(x),
+                  y: scaleY(y) - 20 - (rect?.top ?? 0)
+                });
+              }}
+              onBlur={() => setHovered(null)}
+            >
+              <circle
+                r={scaleR(r)}
+                fill="url(#bubbleGradient)"
+                fillOpacity={isSelected ? 0.95 : 0.6}
+                stroke={isSelected ? "#34d399" : "#0f172a"}
+                strokeWidth={isSelected ? 3 : 1}
+              />
+              <text
+                y={4}
+                textAnchor="middle"
+                className="pointer-events-none text-sm font-semibold"
+                fill="#f8fafc"
+              >
+                {item.title.split(" ")[0]}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {hovered && (
+        <div
+          className="pointer-events-none absolute z-30 rounded-xl border border-emerald-400/30 bg-slate-900/95 px-3 py-2 text-xs text-slate-100 shadow-lg"
+          style={{
+            left: Math.min(Math.max(hovered.x + 12, 0), width - 160),
+            top: Math.max(hovered.y - 40, 0)
+          }}
+        >
+          <p className="font-semibold text-emerald-200">{hovered.item.title}</p>
+          <p>Reach: {hovered.item.reachable}</p>
+          <p>CVR: {hovered.item.cvr}</p>
+          <p>Payback: {hovered.item.payback}</p>
+        </div>
+      )}
+
+      <div className="mt-3 flex items-center gap-3 text-xs text-slate-300">
+        <span className="inline-flex h-3 w-3 rounded-full bg-emerald-400/80" aria-hidden />
+        <span>Size = reach • Darker = higher score • Tap a bubble to drill</span>
+      </div>
+    </div>
+  );
+};
+
+export default MatrixView;

--- a/src/marketRadar/components/PlaybookView.tsx
+++ b/src/marketRadar/components/PlaybookView.tsx
@@ -1,0 +1,120 @@
+/**
+ * Playbook view holds planned cohorts and summarizes reach and lift.
+ */
+import React, { forwardRef, useImperativeHandle, useMemo, useState } from "react";
+import { Archetype } from "../data/mockData";
+import { midRangePercent, midMonths, reachK } from "../utils";
+
+export type PlaybookHandle = {
+  addToPlan: (item: Archetype) => void;
+};
+
+const maxPlan = 3;
+
+const PlaybookView = forwardRef<PlaybookHandle, { selected: Archetype | null }>((props, ref) => {
+  const { selected } = props;
+  const [plan, setPlan] = useState<Archetype[]>([]);
+
+  useImperativeHandle(ref, () => ({
+    addToPlan: (item: Archetype) => {
+      setPlan((prev) => {
+        if (prev.find((p) => p.id === item.id) || prev.length >= maxPlan) {
+          return prev;
+        }
+        return [...prev, item];
+      });
+    }
+  }));
+
+  const totals = useMemo(() => {
+    if (plan.length === 0) {
+      return { reach: 0, cvr: 0, payback: 0 };
+    }
+    const reachSum = plan.reduce((sum, item) => sum + reachK(item.reachable), 0);
+    const cvrAvg = plan.reduce((sum, item) => sum + midRangePercent(item.cvr), 0) / plan.length;
+    const paybackAvg = plan.reduce((sum, item) => sum + midMonths(item.payback), 0) / plan.length;
+    return { reach: reachSum, cvr: cvrAvg, payback: paybackAvg };
+  }, [plan]);
+
+  const remove = (id: number) => setPlan((prev) => prev.filter((item) => item.id !== id));
+
+  const liftEstimate = (item: Archetype) => {
+    const base = midRangePercent(item.cvr);
+    return (base * 1.4).toFixed(1);
+  };
+
+  return (
+    <section className="card flex flex-col gap-4 border border-slate-800 p-4" aria-label="Playbook plan">
+      <header className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-white">Playbook</h3>
+        <span className="text-xs text-slate-400">{plan.length}/{maxPlan} planned</span>
+      </header>
+      <p className="text-xs text-slate-300">
+        Click "Add to plan" on any AI Pick to track it here. {selected ? `Current focus: ${selected.title}.` : "Pick a segment to see more detail."}
+      </p>
+      <div className="space-y-3">
+        {plan.length === 0 && (
+          <div className="rounded-xl border border-dashed border-slate-700 px-4 py-6 text-center text-sm text-slate-400">
+            No cohorts yet. Add up to three high-confidence plays.
+          </div>
+        )}
+        {plan.map((item) => (
+          <div
+            key={item.id}
+            className="rounded-2xl border border-emerald-500/30 bg-slate-900/70 p-4 shadow-soft"
+          >
+            <div className="flex items-start justify-between">
+              <div>
+                <h4 className="text-sm font-semibold text-white">{item.title}</h4>
+                <p className="text-xs text-slate-400">Lift est. {liftEstimate(item)}%</p>
+              </div>
+              <button
+                type="button"
+                className="focus-outline rounded-full bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-200 hover:bg-slate-700"
+                onClick={() => remove(item.id)}
+              >
+                Remove
+              </button>
+            </div>
+            <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-200">
+              <div>
+                <dt className="text-slate-400">Reach</dt>
+                <dd className="font-semibold">{item.reachable}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-400">Expected CVR</dt>
+                <dd className="font-semibold">{item.cvr}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-400">Payback</dt>
+                <dd className="font-semibold">{item.payback}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-400">Confidence</dt>
+                <dd className="font-semibold capitalize">{item.conf}</dd>
+              </div>
+            </dl>
+          </div>
+        ))}
+      </div>
+      <footer className="mt-2 rounded-2xl border border-slate-800 bg-slate-900/60 px-4 py-3 text-xs text-slate-200">
+        <div className="flex items-center justify-between">
+          <span>Total reachable</span>
+          <strong>{totals.reach.toFixed(0)}k</strong>
+        </div>
+        <div className="flex items-center justify-between">
+          <span>Blended CVR</span>
+          <strong>{totals.cvr.toFixed(1)}%</strong>
+        </div>
+        <div className="flex items-center justify-between">
+          <span>Avg. payback</span>
+          <strong>{totals.payback.toFixed(1)} mo</strong>
+        </div>
+      </footer>
+    </section>
+  );
+});
+
+PlaybookView.displayName = "PlaybookView";
+
+export default PlaybookView;

--- a/src/marketRadar/components/TopSummary.tsx
+++ b/src/marketRadar/components/TopSummary.tsx
@@ -1,0 +1,35 @@
+/**
+ * Plain-English summary guiding the user on how to use the Market Radar tab.
+ */
+import React from "react";
+import { Badge } from "./atoms";
+
+const badges = [
+  "Segment-first",
+  "Competitive strip",
+  "Optional map",
+  "AI picks",
+  "Key metrics only"
+];
+
+const TopSummary: React.FC = () => {
+  return (
+    <section className="card mx-auto mb-6 flex flex-col gap-4 border border-emerald-500/20 bg-gradient-to-r from-slate-900 to-slate-800/90 p-6">
+      <header>
+        <h1 className="text-2xl font-semibold text-white">How to use Market Radar</h1>
+      </header>
+      <p className="text-sm leading-relaxed text-slate-200">
+        Define a cohort in Cohort Builder or type a plain-English ask. Use the Market Lens to spot high-yield segments (CVR vs payback, bubble size = reach). Check competitive intensity in the strip below. Open a card to see micro-segments and apply the cohort. The right rail shows only the most important metrics by default.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {badges.map((item) => (
+          <Badge key={item} className="bg-emerald-500/15 text-emerald-200">
+            {item}
+          </Badge>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default TopSummary;

--- a/src/marketRadar/components/atoms.tsx
+++ b/src/marketRadar/components/atoms.tsx
@@ -1,0 +1,101 @@
+/**
+ * Atoms: re-usable UI primitives with Tailwind styling and built-in accessibility.
+ */
+import React from "react";
+import clsx from "clsx";
+
+type BadgeProps = {
+  children: React.ReactNode;
+  color?: "emerald" | "slate" | "amber";
+  className?: string;
+};
+
+export const Badge: React.FC<BadgeProps> = ({ children, color = "emerald", className }) => {
+  const styles = {
+    emerald: "bg-emerald-500/15 text-emerald-200",
+    slate: "bg-slate-800 text-slate-200",
+    amber: "bg-amber-400/20 text-amber-200"
+  };
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide",
+        styles[color],
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+};
+
+type StatProps = {
+  label: string;
+  value: string;
+  accent?: string;
+  ariaLabel?: string;
+};
+
+export const Stat: React.FC<StatProps> = ({ label, value, accent, ariaLabel }) => (
+  <div
+    className="flex flex-col gap-1 rounded-2xl bg-slate-900/80 px-4 py-3 text-slate-100 shadow-soft"
+    aria-label={ariaLabel ?? label}
+  >
+    <span className="text-xs font-medium uppercase tracking-wide text-slate-400">{label}</span>
+    <span className="text-lg font-semibold text-white">{value}</span>
+    {accent && <span className="text-xs text-emerald-300">{accent}</span>}
+  </div>
+);
+
+type MeterProps = {
+  label: string;
+  value: number;
+  max?: number;
+  tone?: "emerald" | "amber" | "slate";
+  helper?: string;
+};
+
+export const Meter: React.FC<MeterProps> = ({ label, value, max = 100, tone = "emerald", helper }) => {
+  const percent = Math.max(0, Math.min(100, (value / max) * 100));
+  const toneClass =
+    tone === "emerald"
+      ? "bg-gradient-to-r from-emerald-500 to-emerald-300"
+      : tone === "amber"
+      ? "bg-gradient-to-r from-amber-500 to-amber-300"
+      : "bg-gradient-to-r from-slate-500 to-slate-300";
+  return (
+    <div className="flex flex-col gap-2" role="group" aria-label={`${label} meter`}>
+      <div className="flex items-center justify-between text-xs text-slate-300">
+        <span>{label}</span>
+        <span className="font-semibold text-slate-100">{Math.round(percent)}%</span>
+      </div>
+      <div className="h-2 w-full rounded-full bg-slate-700">
+        <div
+          className={clsx("h-2 rounded-full transition-all", toneClass)}
+          style={{ width: `${percent}%` }}
+          role="meter"
+          aria-valuenow={Math.round(percent)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        />
+      </div>
+      {helper && <span className="text-xs text-slate-400">{helper}</span>}
+    </div>
+  );
+};
+
+type SectionTitleProps = {
+  title: string;
+  subtitle?: string;
+  action?: React.ReactNode;
+};
+
+export const SectionTitle: React.FC<SectionTitleProps> = ({ title, subtitle, action }) => (
+  <div className="flex items-start justify-between gap-3">
+    <div>
+      <h2 className="text-lg font-semibold text-white">{title}</h2>
+      {subtitle && <p className="text-sm text-slate-300">{subtitle}</p>}
+    </div>
+    {action}
+  </div>
+);

--- a/src/marketRadar/data/mockData.ts
+++ b/src/marketRadar/data/mockData.ts
@@ -1,0 +1,222 @@
+/**
+ * Mock data powering the Market Radar tab. All numbers are illustrative and consistent
+ * with the guided experience we want to demo.
+ */
+
+export type Archetype = {
+  id: number;
+  title: string;
+  reachable: string;
+  cvr: string;
+  payback: string;
+  score: number;
+  conf: "low" | "med" | "high";
+  drivers: string[];
+  rival: string;
+  rivalNote: string;
+  gaps: string[];
+};
+
+export type MicroSegment = {
+  title: string;
+  size: string;
+  reach: string;
+  cvr: string;
+  payback: string;
+  conf: string;
+  why: string;
+};
+
+export const archetypes: Archetype[] = [
+  {
+    id: 1,
+    title: "Remote Revivers",
+    reachable: "180k",
+    cvr: "2.0-2.4%",
+    payback: "5-6 mo",
+    score: 82,
+    conf: "high",
+    drivers: ["Flex billing", "One-week launch"],
+    rival: "Nimbus",
+    rivalNote: "Winning with bundled comms",
+    gaps: ["Async support", "Payroll sync"]
+  },
+  {
+    id: 2,
+    title: "Hybrid HQs",
+    reachable: "150k",
+    cvr: "1.6-1.9%",
+    payback: "6-7 mo",
+    score: 74,
+    conf: "med",
+    drivers: ["Compliance auto", "Facilities dashboard"],
+    rival: "AtlasSoft",
+    rivalNote: "Leading with compliance services",
+    gaps: ["Multi-region ops", "Mobile audit"]
+  },
+  {
+    id: 3,
+    title: "Field Fixers",
+    reachable: "120k",
+    cvr: "1.2-1.6%",
+    payback: "4-5 mo",
+    score: 68,
+    conf: "med",
+    drivers: ["Offline toolkit", "Crew messaging"],
+    rival: "Groundly",
+    rivalNote: "Price-led play",
+    gaps: ["Inventory check", "Route planning"]
+  },
+  {
+    id: 4,
+    title: "Creator Collectives",
+    reachable: "90k",
+    cvr: "2.4-3.0%",
+    payback: "3-4 mo",
+    score: 88,
+    conf: "high",
+    drivers: ["Creator payouts", "Affiliate boosts"],
+    rival: "Pulse",
+    rivalNote: "Strong partner program",
+    gaps: ["Tax wizard", "Campaign insights"]
+  },
+  {
+    id: 5,
+    title: "Legacy Lifters",
+    reachable: "210k",
+    cvr: "0.9-1.2%",
+    payback: "8-9 mo",
+    score: 58,
+    conf: "low",
+    drivers: ["White-glove onboarding", "Finance integrations"],
+    rival: "FirmWare",
+    rivalNote: "Enterprise lock-in",
+    gaps: ["Change management", "Advanced reporting"]
+  }
+];
+
+export const microSegments: Record<number, MicroSegment[]> = {
+  1: [
+    {
+      title: "Series B remote-first",
+      size: "45k",
+      reach: "38k",
+      cvr: "2.4%",
+      payback: "5.2 mo",
+      conf: "High",
+      why: "Buying tools to consolidate vendor stack"
+    },
+    {
+      title: "Global CS pods",
+      size: "70k",
+      reach: "62k",
+      cvr: "2.1%",
+      payback: "5.7 mo",
+      conf: "High",
+      why: "Need async escalations and quality tracking"
+    }
+  ],
+  2: [
+    {
+      title: "Hybrid compliance leads",
+      size: "34k",
+      reach: "28k",
+      cvr: "1.9%",
+      payback: "6.1 mo",
+      conf: "Medium",
+      why: "Regulatory changes driving spend"
+    },
+    {
+      title: "Facilities ops",
+      size: "46k",
+      reach: "39k",
+      cvr: "1.6%",
+      payback: "6.8 mo",
+      conf: "Medium",
+      why: "Need modern audit workflows"
+    }
+  ],
+  3: [
+    {
+      title: "Regional field teams",
+      size: "28k",
+      reach: "24k",
+      cvr: "1.4%",
+      payback: "4.6 mo",
+      conf: "Medium",
+      why: "ROI tied to downtime reduction"
+    },
+    {
+      title: "Maintenance subs",
+      size: "35k",
+      reach: "30k",
+      cvr: "1.3%",
+      payback: "4.9 mo",
+      conf: "Low",
+      why: "Evaluating pricing vs incumbents"
+    }
+  ],
+  4: [
+    {
+      title: "Creator agencies",
+      size: "22k",
+      reach: "19k",
+      cvr: "2.8%",
+      payback: "3.2 mo",
+      conf: "High",
+      why: "Chasing faster payout cycles"
+    },
+    {
+      title: "Collective platforms",
+      size: "31k",
+      reach: "26k",
+      cvr: "2.5%",
+      payback: "3.8 mo",
+      conf: "High",
+      why: "Need affiliate automation"
+    }
+  ],
+  5: [
+    {
+      title: "Legacy ERP users",
+      size: "80k",
+      reach: "64k",
+      cvr: "1.1%",
+      payback: "8.4 mo",
+      conf: "Low",
+      why: "Exploring modernization budget"
+    },
+    {
+      title: "Finance change teams",
+      size: "48k",
+      reach: "40k",
+      cvr: "1.0%",
+      payback: "8.9 mo",
+      conf: "Low",
+      why: "Need onboarding support"
+    }
+  ]
+};
+
+export const competitors = ["Nimbus", "AtlasSoft", "Groundly", "Pulse", "FirmWare"];
+
+export const overlap: string[][] = [
+  ["36%", "22%", "18%", "12%", "8%"],
+  ["28%", "31%", "14%", "16%", "11%"],
+  ["24%", "20%", "33%", "12%", "9%"],
+  ["18%", "16%", "12%", "42%", "11%"],
+  ["32%", "27%", "18%", "9%", "37%"]
+];
+
+export const usStates = [
+  { id: "CA", name: "California", value: 0.82 },
+  { id: "TX", name: "Texas", value: 0.64 },
+  { id: "NY", name: "New York", value: 0.75 },
+  { id: "FL", name: "Florida", value: 0.58 },
+  { id: "IL", name: "Illinois", value: 0.52 },
+  { id: "WA", name: "Washington", value: 0.69 },
+  { id: "GA", name: "Georgia", value: 0.49 },
+  { id: "NC", name: "North Carolina", value: 0.46 },
+  { id: "CO", name: "Colorado", value: 0.55 },
+  { id: "AZ", name: "Arizona", value: 0.43 }
+];

--- a/src/marketRadar/utils.ts
+++ b/src/marketRadar/utils.ts
@@ -1,0 +1,26 @@
+export const midRangePercent = (range: string): number => {
+  const match = range.match(/([0-9]+\.?[0-9]*)-([0-9]+\.?[0-9]*)%/);
+  if (!match) return 0;
+  const low = parseFloat(match[1]);
+  const high = parseFloat(match[2]);
+  return (low + high) / 2;
+};
+
+export const midMonths = (range: string): number => {
+  const match = range.match(/([0-9]+\.?[0-9]*)-([0-9]+\.?[0-9]*)\s*mo/);
+  if (!match) return 0;
+  const low = parseFloat(match[1]);
+  const high = parseFloat(match[2]);
+  return (low + high) / 2;
+};
+
+export const reachK = (value: string): number => {
+  const match = value.match(/([0-9]+\.?[0-9]*)k/);
+  if (!match) return 0;
+  return parseFloat(match[1]);
+};
+
+export const signalStrength = (score: number): number => {
+  const normalized = Math.max(0, Math.min(100, score));
+  return Math.round(60 + (normalized / 100) * 40);
+};

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,76 @@
+/**
+ * storage helpers manage Segment Studio payloads in localStorage for the demo router.
+ */
+export type SegmentPayload = {
+  id: string;
+  name: string;
+  label?: string;
+  chips: string[];
+  filters: Record<string, string[]>;
+  geoWindow: { geo: string; window: string; grain: string };
+  kpis: {
+    opportunityScore: number;
+    reachable: number;
+    expectedCVR: [number, number];
+    paybackMonths: number;
+  };
+  rivals?: string[];
+  pressureIndex?: number;
+  whiteSpace?: number;
+  createdAt: string;
+  version: number;
+};
+
+export const SEG_KEY = "acq_demo_segments_v1";
+
+const getStorage = () => {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return null;
+  }
+  return window.localStorage;
+};
+
+export function loadAll(): SegmentPayload[] {
+  const storage = getStorage();
+  if (!storage) {
+    return [];
+  }
+  try {
+    const raw = storage.getItem(SEG_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed as SegmentPayload[];
+    }
+    return [];
+  } catch (error) {
+    console.warn("Failed to parse segments", error);
+    return [];
+  }
+}
+
+export function saveAll(list: SegmentPayload[]) {
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+  storage.setItem(SEG_KEY, JSON.stringify(list));
+}
+
+export function saveOne(payload: SegmentPayload) {
+  const list = loadAll();
+  const index = list.findIndex((item) => item.id === payload.id);
+  if (index >= 0) {
+    list[index] = payload;
+  } else {
+    list.push(payload);
+  }
+  saveAll(list);
+}
+
+export function getOne(id: string): SegmentPayload | null {
+  const list = loadAll();
+  return list.find((item) => item.id === id) ?? null;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,19 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: "#10b981",
+          light: "#34d399",
+          dark: "#047857"
+        }
+      },
+      boxShadow: {
+        soft: "0 10px 30px -12px rgba(15, 118, 110, 0.3)"
+      }
+    }
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./vitest.setup.ts"
+  }
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- scaffold a Vite + Tailwind React workspace with a modular Market Radar tab
- implement cohort builder, tri-lens centerpiece, competitive strip, AI picks grid, and right-rail metrics with accessible interactions
- add Vitest coverage for tab switching, selection-driven metrics, drawers, and toggles using mock data

## Testing
- pnpm test *(fails: vitest not found because dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e54cc85e60832eb19542d0b3992123