### PR TITLE
feat: add SBM acquire prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Subscriber Base Management — Acquire</title>
+  </head>
+  <body class="bg-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "sbm-acquire-prototype",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.18",
+    "@radix-ui/react-popover": "^1.0.7",
+    "lucide-react": "^0.372.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "recharts": "^2.8.0",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.25",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.11"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -1,0 +1,220 @@
+import { Dialog, Transition } from '@headlessui/react';
+import { ChevronRight, Menu, Share2, SlidersHorizontal, X } from 'lucide-react';
+import { Fragment, useMemo, useState } from 'react';
+import { Link, NavLink, Outlet, useLocation } from 'react-router-dom';
+import { channels, segments } from '../data/seeds';
+import { useGlobalStore } from '../store/globalStore';
+import { currencyFormatter } from '../lib/format';
+
+const nav = [
+  { name: 'Market Radar', href: '/market-radar' },
+  { name: 'Segment Studio', href: '/segment-studio' },
+  { name: 'Campaign Designer', href: '/campaign-designer' }
+];
+
+export const AppLayout = () => {
+  const location = useLocation();
+  const infoPanel = useGlobalStore((state) => state.infoPanel);
+  const assumptions = useGlobalStore((state) => state.assumptions);
+  const updateAssumptions = useGlobalStore((state) => state.updateAssumptions);
+  const [assumptionModalOpen, setAssumptionModalOpen] = useState(false);
+
+  const assumptionSummary = useMemo(
+    () => [
+      `Gross margin ${Math.round(assumptions.grossMarginRate * 100)}%`,
+      `Servicing $${assumptions.servicingCostPerSubMo}/mo`,
+      `Device amort ${assumptions.deviceSubsidyAmortMo} mo`,
+      `Execution $${assumptions.executionCost}`
+    ].join(' • '),
+    [assumptions]
+  );
+
+  const breadcrumb = useMemo(() => {
+    const navItem = nav.find((item) => location.pathname.startsWith(item.href));
+    return navItem?.name ?? 'Market Radar';
+  }, [location.pathname]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-100">
+      <header className="border-b border-slate-200 bg-white/90 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-6 py-4">
+          <div className="flex items-center gap-4">
+            <Menu className="h-5 w-5 text-slate-400" aria-hidden />
+            <div>
+              <Link to="/market-radar" className="text-lg font-semibold text-slate-900">
+                Subscriber Base Management
+              </Link>
+              <div className="flex items-center gap-2 text-sm text-slate-500">
+                <span>Acquire</span>
+                <ChevronRight className="h-4 w-4" />
+                <span>{breadcrumb}</span>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-primary hover:text-primary"
+              onClick={() => {
+                const state = JSON.stringify(localStorage.getItem('sbm-acquire-store'));
+                navigator.clipboard.writeText(state ?? '');
+              }}
+            >
+              <Share2 className="h-4 w-4" /> Save & Share
+            </button>
+          </div>
+        </div>
+        <nav className="mx-auto w-full max-w-7xl px-6">
+          <ul className="flex gap-4 border-t border-slate-200 pt-3 text-sm font-medium text-slate-500">
+            {nav.map((item) => (
+              <li key={item.href}>
+                <NavLink
+                  to={item.href}
+                  className={({ isActive }) =>
+                    `inline-flex items-center gap-2 rounded-full px-4 py-2 transition ${
+                      isActive ? 'bg-primary text-white shadow-sm' : 'hover:bg-slate-200 hover:text-slate-900'
+                    }`
+                  }
+                >
+                  {item.name}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </header>
+
+      <div className="mx-auto flex w-full max-w-7xl flex-1 gap-6 px-6 py-8">
+        <main className="flex-1 space-y-6">
+          <div className="rounded-2xl border border-primary/20 bg-primary/10 px-6 py-4 shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-primary">Scenario assumptions</h2>
+                <p className="text-sm text-primary/80">{assumptionSummary}</p>
+              </div>
+              <button
+                className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-white px-4 py-2 text-sm font-medium text-primary shadow-sm hover:bg-primary/10"
+                onClick={() => setAssumptionModalOpen(true)}
+              >
+                <SlidersHorizontal className="h-4 w-4" /> Quick edit
+              </button>
+            </div>
+          </div>
+          <Outlet />
+        </main>
+        <aside className="sticky top-24 h-fit w-[280px] space-y-4">
+          <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Contextual info</h3>
+            <p className="mt-2 text-base font-semibold text-slate-900">{infoPanel.title}</p>
+            <p className="mt-2 text-sm text-slate-600">{infoPanel.description}</p>
+            {infoPanel.hint ? <p className="mt-4 text-xs text-slate-500">Source: {infoPanel.hint}</p> : null}
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-5 text-sm shadow-sm">
+            <h3 className="font-semibold text-slate-900">Channel reference CAC</h3>
+            <ul className="mt-3 space-y-2 text-slate-600">
+              {channels.map((channel) => (
+                <li key={channel.id} className="flex items-center justify-between">
+                  <span>{channel.name}</span>
+                  <span>{currencyFormatter.format(channel.cac)}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </aside>
+      </div>
+
+      <Transition.Root show={assumptionModalOpen} as={Fragment}>
+        <Dialog as="div" className="relative z-50" onClose={setAssumptionModalOpen}>
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-200"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-150"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-slate-900/40" />
+          </Transition.Child>
+
+          <div className="fixed inset-0 overflow-y-auto">
+            <div className="flex min-h-full items-center justify-center p-6">
+              <Transition.Child
+                as={Fragment}
+                enter="ease-out duration-200"
+                enterFrom="opacity-0 translate-y-4"
+                enterTo="opacity-100 translate-y-0"
+                leave="ease-in duration-150"
+                leaveFrom="opacity-100 translate-y-0"
+                leaveTo="opacity-0 translate-y-4"
+              >
+                <Dialog.Panel className="w-full max-w-lg rounded-3xl border border-slate-200 bg-white p-6 shadow-xl">
+                  <div className="flex items-center justify-between">
+                    <Dialog.Title className="text-lg font-semibold text-slate-900">Edit economic assumptions</Dialog.Title>
+                    <button
+                      className="rounded-full p-2 text-slate-500 hover:bg-slate-100"
+                      onClick={() => setAssumptionModalOpen(false)}
+                      aria-label="Close"
+                    >
+                      <X className="h-5 w-5" />
+                    </button>
+                  </div>
+                  <div className="mt-4 grid grid-cols-2 gap-4 text-sm">
+                    <label className="flex flex-col gap-2">
+                      <span className="font-medium text-slate-600">Gross margin rate (%)</span>
+                      <input
+                        type="number"
+                        min={0}
+                        max={100}
+                        value={Math.round(assumptions.grossMarginRate * 100)}
+                        onChange={(event) => updateAssumptions({ grossMarginRate: Number(event.target.value) / 100 })}
+                        className="rounded-xl border border-slate-300 px-3 py-2"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-2">
+                      <span className="font-medium text-slate-600">Servicing cost ($/mo)</span>
+                      <input
+                        type="number"
+                        min={0}
+                        value={assumptions.servicingCostPerSubMo}
+                        onChange={(event) => updateAssumptions({ servicingCostPerSubMo: Number(event.target.value) })}
+                        className="rounded-xl border border-slate-300 px-3 py-2"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-2">
+                      <span className="font-medium text-slate-600">Device amortization (mo)</span>
+                      <input
+                        type="number"
+                        min={1}
+                        value={assumptions.deviceSubsidyAmortMo}
+                        onChange={(event) => updateAssumptions({ deviceSubsidyAmortMo: Number(event.target.value) })}
+                        className="rounded-xl border border-slate-300 px-3 py-2"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-2">
+                      <span className="font-medium text-slate-600">Execution cost ($)</span>
+                      <input
+                        type="number"
+                        min={0}
+                        value={assumptions.executionCost}
+                        onChange={(event) => updateAssumptions({ executionCost: Number(event.target.value) })}
+                        className="rounded-xl border border-slate-300 px-3 py-2"
+                      />
+                    </label>
+                  </div>
+                  <div className="mt-6 flex justify-end">
+                    <button
+                      onClick={() => setAssumptionModalOpen(false)}
+                      className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm"
+                    >
+                      Done
+                    </button>
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition.Root>
+    </div>
+  );
+};

--- a/src/app/routes/CampaignDesigner.tsx
+++ b/src/app/routes/CampaignDesigner.tsx
@@ -1,0 +1,480 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { InfoPopover } from '../../components/InfoPopover';
+import { channels } from '../../data/seeds';
+import { currencyFormatter, formatPayback } from '../../lib/format';
+import { buildRecommendation, generateMicroSegments, normaliseMix } from '../../lib/microSegments';
+import { parseIntent, describeIntent } from '../../lib/intentParser';
+import { getOfferById, runCohort } from '../../sim/tinySim';
+import { useActiveSegment, useGlobalStore } from '../../store/globalStore';
+
+interface PlanMicroSummary {
+  micro: ReturnType<typeof generateMicroSegments>[number];
+  summary: ReturnType<typeof runCohort>;
+  offerConfig: {
+    offerId: string;
+    price: number;
+    promoMonths: number;
+    promoValue: number;
+    deviceSubsidy: number;
+  };
+  channelMix: Record<string, number>;
+}
+
+export const CampaignDesignerRoute = () => {
+  const activeSegment = useActiveSegment();
+  const selectedMicroIds = useGlobalStore((state) => state.selectedMicroSegmentIds);
+  const recommendations = useGlobalStore((state) => state.recommendationsByMicroSegment);
+  const campaign = useGlobalStore((state) => state.campaign);
+  const setCampaign = useGlobalStore((state) => state.setCampaign);
+  const setInfoPanel = useGlobalStore((state) => state.setInfoPanel);
+  const setSelectedMicroSegments = useGlobalStore((state) => state.setSelectedMicroSegments);
+
+  const micros = useMemo(() => generateMicroSegments(activeSegment), [activeSegment]);
+
+  useEffect(() => {
+    if (!selectedMicroIds.length) {
+      return;
+    }
+    setCampaign((prev) => {
+      let changed = false;
+      const offers: typeof prev.offers = { ...prev.offers };
+      const channelMix: typeof prev.channelMix = { ...prev.channelMix };
+      let budget = prev.budget;
+      let totalPotential = 0;
+      selectedMicroIds.forEach((microId) => {
+        const micro = micros.find((item) => item.id === microId);
+        if (!micro) return;
+        const recommendation = recommendations[microId] ?? buildRecommendation(micro);
+        const offer = getOfferById(recommendation.offerArchetypeId);
+        offers[microId] = {
+          offerId: recommendation.offerArchetypeId,
+          price: offer.monthlyPrice,
+          promoMonths: offer.promoMonths,
+          promoValue: offer.promoValue,
+          deviceSubsidy: offer.deviceSubsidy
+        };
+        channelMix[microId] = normaliseMix(recommendation.channelMix);
+        totalPotential += recommendation.expected.netAdds;
+      });
+      if (selectedMicroIds.some((id) => !prev.audienceIds.includes(id)) || prev.audienceIds.length !== selectedMicroIds.length) {
+        changed = true;
+      }
+      const cleanedOffers = Object.fromEntries(Object.entries(offers).filter(([id]) => selectedMicroIds.includes(id)));
+      const cleanedMix = Object.fromEntries(Object.entries(channelMix).filter(([id]) => selectedMicroIds.includes(id)));
+      if (Object.keys(cleanedOffers).length !== Object.keys(prev.offers).length) changed = true;
+      if (Object.keys(cleanedMix).length !== Object.keys(prev.channelMix).length) changed = true;
+      const recommendedBudget = Math.round(totalPotential * 45);
+      if (recommendedBudget && Math.abs(recommendedBudget - prev.budget) > 1000) {
+        budget = recommendedBudget;
+        changed = true;
+      }
+      if (!changed) {
+        return prev;
+      }
+      return {
+        ...prev,
+        audienceIds: selectedMicroIds,
+        offers: cleanedOffers,
+        channelMix: cleanedMix,
+        budget,
+        schedule: prev.schedule ?? { weeks: 12, waves: 2 },
+        guardrails: prev.guardrails ?? { cacCeiling: 350, paybackMax: 8 }
+      };
+    });
+  }, [micros, recommendations, selectedMicroIds, setCampaign]);
+
+  const planMicros = useMemo(
+    () => micros.filter((micro) => campaign.audienceIds.includes(micro.id)),
+    [micros, campaign.audienceIds]
+  );
+
+  const planSummaries: PlanMicroSummary[] = planMicros.map((micro) => {
+    const config = campaign.offers[micro.id];
+    const baseOffer = getOfferById(config?.offerId ?? micro.defaultOfferId);
+    const offer = {
+      ...baseOffer,
+      monthlyPrice: config?.price ?? baseOffer.monthlyPrice,
+      promoMonths: config?.promoMonths ?? baseOffer.promoMonths,
+      promoValue: config?.promoValue ?? baseOffer.promoValue,
+      deviceSubsidy: config?.deviceSubsidy ?? baseOffer.deviceSubsidy
+    };
+    const mix = campaign.channelMix[micro.id] ?? normaliseMix(micro.defaultChannelMix);
+    const summary = runCohort({
+      segment: {
+        id: micro.id,
+        name: micro.name,
+        size: micro.size,
+        priceSensitivity: micro.priceSensitivity,
+        valueSensitivity: micro.valueSensitivity,
+        growthRate: activeSegment.growthRate
+      },
+      offer,
+      channelMix: mix
+    });
+    return {
+      micro,
+      summary,
+      offerConfig: {
+        offerId: offer.id,
+        price: offer.monthlyPrice,
+        promoMonths: offer.promoMonths,
+        promoValue: offer.promoValue,
+        deviceSubsidy: offer.deviceSubsidy
+      },
+      channelMix: mix
+    };
+  });
+
+  const totals = planSummaries.reduce(
+    (acc, entry) => {
+      acc.netAdds += entry.summary.netAdds;
+      acc.grossMargin += entry.summary.grossMargin12Mo;
+      const payback = parseInt(entry.summary.paybackMonths, 10);
+      if (!Number.isNaN(payback)) acc.paybackMonths.push(payback);
+      acc.cac += entry.summary.cac;
+      return acc;
+    },
+    { netAdds: 0, grossMargin: 0, paybackMonths: [] as number[], cac: 0 }
+  );
+  const blendedPayback = totals.paybackMonths.length
+    ? `${Math.round(totals.paybackMonths.reduce((sum, value) => sum + value, 0) / totals.paybackMonths.length)} mo`
+    : '—';
+
+  const channelSpendData = useMemo(() => {
+    if (!planSummaries.length) return [];
+    const weeks = campaign.schedule?.weeks ?? 12;
+    const total = campaign.budget || 0;
+    const waves = campaign.schedule?.waves ?? 2;
+    const waveLength = Math.round(weeks / waves);
+    return Array.from({ length: weeks }).map((_, index) => {
+      const waveFactor = 1 + (index % waveLength === 0 ? 0.15 : 0);
+      const spendBase = (total / weeks) * waveFactor;
+      const entry: Record<string, number | string> = { week: `W${index + 1}` };
+      channels.forEach((channel) => {
+        const mixAvg = planSummaries.reduce((sum, summary) => sum + (summary.channelMix[channel.id] ?? 0), 0) / planSummaries.length;
+        entry[channel.name] = Math.round(spendBase * mixAvg);
+      });
+      return entry;
+    });
+  }, [planSummaries, campaign.budget, campaign.schedule]);
+
+  const [command, setCommand] = useState('');
+  const [changeLog, setChangeLog] = useState<string[]>([]);
+
+  const applyIntent = (input: string) => {
+    if (!input.trim()) return;
+    const intent = parseIntent(input, {
+      microSegments: planMicros
+    });
+    setCampaign((prev) => {
+      let next = { ...prev, offers: { ...prev.offers }, channelMix: { ...prev.channelMix }, audienceIds: [...prev.audienceIds] };
+      if (intent.channelShifts.length) {
+        for (const shift of intent.channelShifts) {
+          next.channelMix = Object.fromEntries(
+            Object.entries(next.channelMix).map(([microId, mix]) => {
+              const current = { ...mix };
+              const fromWeight = shift.from ? current[shift.from] ?? 0 : 0;
+              const toWeight = shift.to ? current[shift.to] ?? 0 : 0;
+              if (shift.from) current[shift.from] = Math.max(0, fromWeight - shift.delta);
+              if (shift.to) current[shift.to] = Math.min(1, toWeight + shift.delta);
+              return [microId, normaliseMix(current)];
+            })
+          );
+        }
+      }
+      if (intent.channelAdjusts.length) {
+        next.channelMix = Object.fromEntries(
+          Object.entries(next.channelMix).map(([microId, mix]) => {
+            const current = { ...mix };
+            intent.channelAdjusts.forEach((adjust) => {
+              if (adjust.channelId in current) {
+                current[adjust.channelId] = Math.max(0.05, current[adjust.channelId] + adjust.delta);
+              }
+            });
+            return [microId, normaliseMix(current)];
+          })
+        );
+      }
+      if (intent.offerAdjustments.priceDelta || intent.offerAdjustments.promoMonthsDelta || intent.offerAdjustments.promoValueDelta || intent.offerAdjustments.deviceSubsidyDelta) {
+        next.offers = Object.fromEntries(
+          Object.entries(next.offers).map(([microId, offer]) => [
+            microId,
+            {
+              ...offer,
+              price: Math.max(35, offer.price + (intent.offerAdjustments.priceDelta ?? 0)),
+              promoMonths: Math.max(0, offer.promoMonths + (intent.offerAdjustments.promoMonthsDelta ?? 0)),
+              promoValue: Math.max(0, offer.promoValue + (intent.offerAdjustments.promoValueDelta ?? 0)),
+              deviceSubsidy: Math.max(0, offer.deviceSubsidy + (intent.offerAdjustments.deviceSubsidyDelta ?? 0))
+            }
+          ])
+        );
+      }
+      if (intent.audienceChange) {
+        let updatedAudience = next.audienceIds;
+        if (intent.audienceChange.include) {
+          updatedAudience = Array.from(new Set([...updatedAudience, ...intent.audienceChange.include]));
+          setSelectedMicroSegments(Array.from(new Set([...selectedMicroIds, ...intent.audienceChange.include])));
+        }
+        if (intent.audienceChange.exclude) {
+          updatedAudience = updatedAudience.filter((id) => !intent.audienceChange.exclude?.includes(id));
+          setSelectedMicroSegments(selectedMicroIds.filter((id) => !intent.audienceChange.exclude?.includes(id)));
+        }
+        next.audienceIds = updatedAudience;
+      }
+      if (intent.budgetDelta) {
+        next.budget = Math.max(0, next.budget + intent.budgetDelta);
+      }
+      if (intent.paybackTarget) {
+        next.guardrails = { ...next.guardrails, paybackMax: intent.paybackTarget };
+      }
+      return next;
+    });
+    setChangeLog((log) => [`${new Date().toLocaleTimeString()} — ${describeIntent(intent)}`, ...log.slice(0, 6)]);
+    setCommand('');
+  };
+
+  const handleOfferFieldChange = (microId: string, field: 'price' | 'promoMonths' | 'promoValue' | 'deviceSubsidy', value: number) => {
+    setCampaign((prev) => ({
+      ...prev,
+      offers: {
+        ...prev.offers,
+        [microId]: {
+          ...prev.offers[microId],
+          [field]: value
+        }
+      }
+    }));
+  };
+
+  const handleChannelFieldChange = (microId: string, channelId: string, value: number) => {
+    setCampaign((prev) => ({
+      ...prev,
+      channelMix: {
+        ...prev.channelMix,
+        [microId]: normaliseMix({ ...(prev.channelMix[microId] ?? {}), [channelId]: value })
+      }
+    }));
+  };
+
+  if (!selectedMicroIds.length) {
+    return (
+      <div className="rounded-3xl border border-dashed border-slate-300 bg-white p-12 text-center shadow-sm">
+        <h2 className="text-xl font-semibold text-slate-900">No micro-segments selected</h2>
+        <p className="mt-2 text-sm text-slate-600">Head back to Segment Studio to choose who this campaign should target.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Audience</h2>
+            <p className="text-sm text-slate-600">{planMicros.length} micro-segments in scope. Hover for traits.</p>
+          </div>
+          <InfoPopover title="Audience" plainDescription="The micro-segments included in this campaign flight." primarySourceHint="Synth clustering" />
+        </div>
+        <div className="mt-4 flex flex-wrap gap-3">
+          {planMicros.map((micro) => (
+            <button
+              key={micro.id}
+              className="group rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-700 hover:border-primary hover:text-primary"
+              onMouseEnter={() =>
+                setInfoPanel({
+                  title: micro.name,
+                  description: micro.traits.join(' • '),
+                  hint: 'Synth persona blend'
+                })
+              }
+            >
+              {micro.name}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Offers</h2>
+            <p className="text-sm text-slate-600">Light tweaks per micro-segment update TinySim instantly.</p>
+          </div>
+          <InfoPopover
+            title="Offer controls"
+            plainDescription="Edit monthly price, promo depth, or device subsidy for each micro-segment offer."
+            primarySourceHint="Synth plan archetypes"
+          />
+        </div>
+        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {planSummaries.map(({ micro, offerConfig }) => (
+            <div key={micro.id} className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm">
+              <h3 className="font-semibold text-slate-900">{micro.name}</h3>
+              <div className="mt-3 space-y-3">
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-semibold uppercase text-slate-500">Monthly price</span>
+                  <input
+                    type="number"
+                    value={offerConfig.price}
+                    onChange={(event) => handleOfferFieldChange(micro.id, 'price', Number(event.target.value))}
+                    className="rounded-xl border border-slate-300 px-3 py-2"
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-semibold uppercase text-slate-500">Promo months</span>
+                  <input
+                    type="number"
+                    value={offerConfig.promoMonths}
+                    onChange={(event) => handleOfferFieldChange(micro.id, 'promoMonths', Number(event.target.value))}
+                    className="rounded-xl border border-slate-300 px-3 py-2"
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-semibold uppercase text-slate-500">Promo value</span>
+                  <input
+                    type="number"
+                    value={offerConfig.promoValue}
+                    onChange={(event) => handleOfferFieldChange(micro.id, 'promoValue', Number(event.target.value))}
+                    className="rounded-xl border border-slate-300 px-3 py-2"
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-semibold uppercase text-slate-500">Device subsidy</span>
+                  <input
+                    type="number"
+                    value={offerConfig.deviceSubsidy}
+                    onChange={(event) => handleOfferFieldChange(micro.id, 'deviceSubsidy', Number(event.target.value))}
+                    className="rounded-xl border border-slate-300 px-3 py-2"
+                  />
+                </label>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Channel plan</h2>
+            <p className="text-sm text-slate-600">Budget ${currencyFormatter.format(campaign.budget)} across {campaign.schedule?.weeks ?? 12} weeks.</p>
+          </div>
+          <InfoPopover
+            title="Channel plan"
+            plainDescription="Weekly spend allocation simulated from current weights and budget."
+            primarySourceHint="Synth CAC curves"
+          />
+        </div>
+        <div className="mt-4 grid gap-6 lg:grid-cols-[minmax(0,1fr)_280px]">
+          <div className="h-72 rounded-2xl bg-slate-50 p-4">
+            <ResponsiveContainer>
+              <BarChart data={channelSpendData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="week" />
+                <YAxis tickFormatter={(value) => `$${value}`}></YAxis>
+                <Tooltip formatter={(value: number) => currencyFormatter.format(value)} />
+                <Legend />
+                {channels.map((channel) => (
+                  <Bar key={channel.id} dataKey={channel.name} stackId="a" fill="#1f7aec" fillOpacity={0.35 + channels.indexOf(channel) * 0.15} />
+                ))}
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="rounded-2xl bg-slate-50 p-4 text-sm">
+            <h3 className="font-semibold text-slate-900">Channel weights</h3>
+            <ul className="mt-3 space-y-2">
+              {planSummaries.map(({ micro, channelMix }) => (
+                <li key={micro.id} className="rounded-xl border border-slate-200 bg-white p-3">
+                  <p className="text-sm font-semibold text-slate-900">{micro.name}</p>
+                  <div className="mt-2 space-y-2 text-xs">
+                    {channels.map((channel) => (
+                      <label key={channel.id} className="flex items-center justify-between gap-2">
+                        <span>{channel.name}</span>
+                        <input
+                          type="range"
+                          min={5}
+                          max={80}
+                          step={5}
+                          value={Math.round((channelMix[channel.id] ?? 0) * 100)}
+                          onChange={(event) => handleChannelFieldChange(micro.id, channel.id, Number(event.target.value) / 100)}
+                        />
+                      </label>
+                    ))}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Expected outcomes</h2>
+            <p className="text-sm text-slate-600">TinySim recalculates whenever you adjust offers or mix.</p>
+          </div>
+          <InfoPopover
+            title="Outcome KPIs"
+            plainDescription="Shows CAC payback, 12-mo gross margin, and net adds based on TinySim calculations."
+            primarySourceHint="Synth Cohort Econ."
+          />
+        </div>
+        <div className="mt-4 grid gap-4 md:grid-cols-3">
+          <div className="rounded-2xl bg-slate-50 p-4">
+            <p className="text-xs font-semibold uppercase text-slate-500">Blended payback</p>
+            <p className="mt-2 text-3xl font-semibold text-slate-900">{blendedPayback}</p>
+          </div>
+          <div className="rounded-2xl bg-slate-50 p-4">
+            <p className="text-xs font-semibold uppercase text-slate-500">12-mo gross margin</p>
+            <p className="mt-2 text-3xl font-semibold text-slate-900">{currencyFormatter.format(totals.grossMargin)}</p>
+          </div>
+          <div className="rounded-2xl bg-slate-50 p-4">
+            <p className="text-xs font-semibold uppercase text-slate-500">Net adds</p>
+            <p className="mt-2 text-3xl font-semibold text-slate-900">{totals.netAdds.toLocaleString()}</p>
+          </div>
+        </div>
+        <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+          <p>Guardrails: CAC ceiling {currencyFormatter.format(campaign.guardrails?.cacCeiling ?? 0)}, payback ≤ {campaign.guardrails?.paybackMax ?? '—'} months.</p>
+        </div>
+      </section>
+
+      <section className="sticky bottom-6 rounded-3xl border border-primary/40 bg-white p-4 shadow-xl">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-primary">Command bar</h3>
+            <InfoPopover
+              title="LLM-like command"
+              plainDescription="Type adjustments in natural language to fine-tune offers, channels, or budget."
+              primarySourceHint="Synth intent parser"
+            />
+          </div>
+          <form
+            className="flex w-full flex-1 items-center gap-3"
+            onSubmit={(event) => {
+              event.preventDefault();
+              applyIntent(command);
+            }}
+          >
+            <input
+              type="text"
+              value={command}
+              onChange={(event) => setCommand(event.target.value)}
+              placeholder="Make payback ≤ 6 months by shifting 10% budget from Retail to Search..."
+              className="flex-1 rounded-full border border-slate-300 px-4 py-2"
+            />
+            <button type="submit" className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm">
+              Apply
+            </button>
+          </form>
+        </div>
+        <div className="mt-3 space-y-1 text-xs text-slate-500">
+          {changeLog.map((item, index) => (
+            <p key={index}>{item}</p>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/app/routes/MarketRadar.tsx
+++ b/src/app/routes/MarketRadar.tsx
@@ -1,0 +1,362 @@
+import { Dialog, Transition } from '@headlessui/react';
+import { ArrowRight, Filter, SlidersHorizontal, Sparkles, X } from 'lucide-react';
+import { Fragment, useMemo, useState } from 'react';
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { channels, competitors, segments } from '../../data/seeds';
+import { InfoPopover } from '../../components/InfoPopover';
+import { KpiCard } from '../../components/KpiCard';
+import { SegmentCard } from '../../components/SegmentCard';
+import { CompareDrawer } from '../../components/CompareDrawer';
+import { CompetitorHeatmap } from '../../components/CompetitorHeatmap';
+import { MigrationMatrix } from '../../components/MigrationMatrix';
+import { currencyFormatter, formatPayback, percentFormatter } from '../../lib/format';
+import { summariseCohort } from '../../sim/tinySim';
+import { useGlobalStore } from '../../store/globalStore';
+
+const heroInfo = {
+  payback: {
+    description: 'How long until gross margin from this cohort covers the fully-loaded CAC (channel + promo + device).',
+    formula: 'min m where Σ(Contribution₁..m) ≥ CAC',
+    source: 'Synth Cohort Econ.'
+  },
+  grossMargin: {
+    description: 'Gross margin from this cohort over 12 months after servicing costs and device amortization.',
+    formula: 'Σ₁₋₁₂(Gross Margin - Servicing - Device amort)',
+    source: 'Synth Cohort Econ.'
+  }
+};
+
+const aiSummaryBullets = () => {
+  const topValue = [...competitors].sort((a, b) => b.valueScore - a.valueScore)[0];
+  const bestPrice = [...competitors].sort((a, b) => a.basePrice - b.basePrice)[0];
+  return [
+    `${topValue.name} leads perceived value at ${topValue.valueScore} while charging $${topValue.basePrice}, signalling room for bundle storytelling.`,
+    `${bestPrice.name} anchors entry pricing at $${bestPrice.basePrice} with ${bestPrice.promoStyle.toLowerCase()}, so promo discipline is key.`
+  ];
+};
+
+export const MarketRadarRoute = () => {
+  const activeSegmentId = useGlobalStore((state) => state.activeSegmentId);
+  const setActiveSegmentId = useGlobalStore((state) => state.setActiveSegmentId);
+  const setInfoPanel = useGlobalStore((state) => state.setInfoPanel);
+  const [filters, setFilters] = useState({ region: 'all', price: 'all', value: 'all', size: 'all' });
+  const [compareIds, setCompareIds] = useState<string[]>([]);
+  const [showCompare, setShowCompare] = useState(false);
+  const [assumptionModal, setAssumptionModal] = useState(false);
+
+  const filteredSegments = useMemo(() => {
+    return segments.filter((segment) => {
+      const matchRegion = filters.region === 'all' || segment.regionMix[filters.region] !== undefined;
+      const matchPrice =
+        filters.price === 'all' || (filters.price === 'sensitive' ? segment.priceSensitivity > 0.6 : segment.priceSensitivity <= 0.6);
+      const matchValue =
+        filters.value === 'all' || (filters.value === 'high' ? segment.valueSensitivity >= 0.7 : segment.valueSensitivity < 0.7);
+      const matchSize =
+        filters.size === 'all' || (filters.size === 'large' ? segment.size >= 300000 : segment.size < 300000);
+      return matchRegion && matchPrice && matchValue && matchSize;
+    });
+  }, [filters]);
+
+  const activeSegment =
+    filteredSegments.find((segment) => segment.id === activeSegmentId) ??
+    segments.find((segment) => segment.id === activeSegmentId) ??
+    segments[0];
+
+  const heroSummary = summariseCohort(activeSegment);
+  const channelMix = activeSegment.defaultChannelMix;
+  const channelCacComponent = Object.entries(channelMix).reduce((sum, [channelId, weight]) => {
+    const channel = channels.find((c) => c.id === channelId);
+    if (!channel) return sum;
+    return sum + channel.cac * weight;
+  }, 0);
+  const promoDeviceExecution = heroSummary.cacPerSubscriber - channelCacComponent;
+
+  const contributionSeries = heroSummary.contributionPerMonth.map((value, index) => ({ month: index + 1, contribution: value }));
+
+  return (
+    <div className="space-y-8">
+      <section aria-label="Filters and assumptions" className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-wide text-slate-500">
+          <Filter className="h-4 w-4" /> Filter segments
+        </div>
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium text-slate-600">Region signal</span>
+            <select
+              value={filters.region}
+              onChange={(event) => setFilters((prev) => ({ ...prev, region: event.target.value }))}
+              className="rounded-xl border border-slate-300 px-3 py-2"
+            >
+              <option value="all">All</option>
+              <option value="urban">Urban heavy</option>
+              <option value="suburban">Suburban mix</option>
+              <option value="rural">Rural skew</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium text-slate-600">Price sensitivity</span>
+            <select
+              value={filters.price}
+              onChange={(event) => setFilters((prev) => ({ ...prev, price: event.target.value }))}
+              className="rounded-xl border border-slate-300 px-3 py-2"
+            >
+              <option value="all">All</option>
+              <option value="sensitive">Higher sensitivity</option>
+              <option value="balanced">Balanced or lower</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium text-slate-600">Value orientation</span>
+            <select
+              value={filters.value}
+              onChange={(event) => setFilters((prev) => ({ ...prev, value: event.target.value }))}
+              className="rounded-xl border border-slate-300 px-3 py-2"
+            >
+              <option value="all">All</option>
+              <option value="high">Value seeking</option>
+              <option value="low">Utility driven</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium text-slate-600">Segment size</span>
+            <select
+              value={filters.size}
+              onChange={(event) => setFilters((prev) => ({ ...prev, size: event.target.value }))}
+              className="rounded-xl border border-slate-300 px-3 py-2"
+            >
+              <option value="all">All</option>
+              <option value="large">Large (≥300K)</option>
+              <option value="small">Smaller (&lt;300K)</option>
+            </select>
+          </label>
+        </div>
+      </section>
+
+      <section aria-label="Hero KPIs" className="grid gap-4 md:grid-cols-2">
+        <KpiCard
+          title="CAC Payback"
+          value={formatPayback(heroSummary.paybackMonths)}
+          deltaLabel={`Reach ${(heroSummary.reach * 100).toFixed(1)}% • Take rate ${(heroSummary.takeRate * 100).toFixed(1)}%`}
+          trend={heroSummary.paybackMonths === '>24' ? 'down' : 'up'}
+          info={heroInfo.payback}
+          onFocus={() =>
+            setInfoPanel({
+              title: 'CAC Payback (months)',
+              description: 'Months until fully loaded CAC is covered by cohort contribution.',
+              hint: 'Synth Cohort Econ.'
+            })
+          }
+        />
+        <KpiCard
+          title="12-mo Incremental Gross Margin"
+          value={currencyFormatter.format(heroSummary.grossMargin12Mo)}
+          deltaLabel={`Net adds est. ${heroSummary.netAdds.toLocaleString()}`}
+          trend="up"
+          info={heroInfo.grossMargin}
+          onFocus={() =>
+            setInfoPanel({
+              title: '12-mo Incremental GM',
+              description: 'Gross margin less servicing + device amort across first 12 months.',
+              hint: 'Synth Cohort Econ.'
+            })
+          }
+        />
+      </section>
+
+      <button className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline" onClick={() => setAssumptionModal(true)}>
+        <SlidersHorizontal className="h-4 w-4" /> Assumptions detail
+      </button>
+
+      <section aria-label="Segment carousel" className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">Segment carousel</h2>
+          <p className="text-sm text-slate-500">Use arrow keys or scroll to explore.</p>
+        </div>
+        <div className="relative">
+          <div
+            className="flex gap-4 overflow-x-auto pb-4"
+            role="listbox"
+            aria-label="Segments"
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (!['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(event.key)) return;
+              const currentIndex = filteredSegments.findIndex((segment) => segment.id === activeSegment.id);
+              if (event.key === 'ArrowRight' && currentIndex < filteredSegments.length - 1) {
+                setActiveSegmentId(filteredSegments[currentIndex + 1].id);
+              }
+              if (event.key === 'ArrowLeft' && currentIndex > 0) {
+                setActiveSegmentId(filteredSegments[currentIndex - 1].id);
+              }
+              if (event.key === 'Home') setActiveSegmentId(filteredSegments[0].id);
+              if (event.key === 'End') setActiveSegmentId(filteredSegments[filteredSegments.length - 1].id);
+            }}
+          >
+            {filteredSegments.map((segment) => (
+              <SegmentCard
+                key={segment.id}
+                segment={segment}
+                active={segment.id === activeSegment.id}
+                comparing={compareIds.includes(segment.id)}
+                onSelect={() => setActiveSegmentId(segment.id)}
+                onToggleCompare={(checked) => {
+                  setCompareIds((prev) => {
+                    if (!checked) return prev.filter((id) => id !== segment.id);
+                    if (prev.length >= 3) return prev;
+                    const next = [...new Set([...prev, segment.id])];
+                    if (next.length > 0) setShowCompare(true);
+                    return next;
+                  });
+                }}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center justify-between text-sm text-slate-500">
+          <span>{filteredSegments.length} segment options shown</span>
+          <button
+            className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-3 py-1 text-sm text-slate-600 hover:border-primary hover:text-primary"
+            onClick={() => setShowCompare(true)}
+            disabled={!compareIds.length}
+          >
+            <Sparkles className="h-4 w-4" /> Compare shortlist
+          </button>
+        </div>
+      </section>
+
+      <section aria-label="Competitor landscape" className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">Competitive landscape</h2>
+          <InfoPopover
+            title="Competitive block"
+            plainDescription="Explore pricing, value, and switching behaviour to position our play."
+            primarySourceHint="Synth pricing + sentiment"
+          />
+        </div>
+        <div className="grid gap-6 xl:grid-cols-2">
+          <CompetitorHeatmap />
+          <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="flex items-center justify-between">
+              <h3 className="text-base font-semibold text-slate-900">Plan snapshot</h3>
+              <InfoPopover title="Plan snapshot" plainDescription="Comparable plan constructs across key competitors." primarySourceHint="Synth plan/pricing" />
+            </div>
+            <div className="mt-4 overflow-auto">
+              <table className="min-w-full border-separate border-spacing-0 text-sm">
+                <thead>
+                  <tr>
+                    <th className="sticky left-0 bg-white px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Brand</th>
+                    <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Base price</th>
+                    <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Promo style</th>
+                    <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Bundle</th>
+                    <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Effective price mo12</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {competitors.map((competitor) => (
+                    <tr key={competitor.id} className="even:bg-slate-50/60">
+                      <th scope="row" className="sticky left-0 bg-white px-4 py-3 text-left font-medium text-slate-700">
+                        {competitor.name}
+                      </th>
+                      <td className="px-4 py-3 text-slate-600">{currencyFormatter.format(competitor.basePrice)}</td>
+                      <td className="px-4 py-3 text-slate-600">{competitor.promoStyle}</td>
+                      <td className="px-4 py-3 text-slate-600">{competitor.bundleFlag ? 'Yes' : 'No'}</td>
+                      <td className="px-4 py-3 text-slate-600">{currencyFormatter.format(competitor.basePrice - competitor.promoDepth)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="mt-3 text-xs text-slate-500">Estimates from synthetic data.</p>
+          </div>
+          <MigrationMatrix />
+          <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="flex items-center justify-between">
+              <h3 className="text-base font-semibold text-slate-900">AI summary</h3>
+              <Sparkles className="h-4 w-4 text-primary" />
+            </div>
+            <ul className="mt-3 space-y-2 text-sm text-slate-600">
+              {aiSummaryBullets().map((bullet, index) => (
+                <li key={index} className="flex items-start gap-2">
+                  <ArrowRight className="mt-1 h-4 w-4 text-primary" />
+                  <span>{bullet}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <CompareDrawer open={showCompare} onClose={() => setShowCompare(false)} segments={segments.filter((segment) => compareIds.includes(segment.id))} />
+
+      <Transition.Root show={assumptionModal} as={Fragment}>
+        <Dialog as="div" className="relative z-50" onClose={setAssumptionModal}>
+          <Transition.Child as={Fragment} enter="ease-out duration-200" enterFrom="opacity-0" enterTo="opacity-100" leave="ease-in duration-150" leaveFrom="opacity-100" leaveTo="opacity-0">
+            <div className="fixed inset-0 bg-slate-900/40" />
+          </Transition.Child>
+          <div className="fixed inset-0 overflow-y-auto">
+            <div className="flex min-h-full items-center justify-center p-6">
+              <Transition.Child as={Fragment} enter="ease-out duration-200" enterFrom="opacity-0 translate-y-4" enterTo="opacity-100 translate-y-0" leave="ease-in duration-150" leaveFrom="opacity-100 translate-y-0" leaveTo="opacity-0 translate-y-4">
+                <Dialog.Panel className="w-full max-w-3xl rounded-3xl border border-slate-200 bg-white p-6 shadow-xl">
+                  <div className="flex items-center justify-between">
+                    <Dialog.Title className="text-lg font-semibold text-slate-900">Assumption breakdown</Dialog.Title>
+                    <button onClick={() => setAssumptionModal(false)} className="rounded-full p-2 text-slate-500 hover:bg-slate-100" aria-label="Close">
+                      <X className="h-5 w-5" />
+                    </button>
+                  </div>
+                  <div className="mt-6 grid gap-4 md:grid-cols-2">
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm">
+                      <h4 className="font-semibold text-slate-900">CAC breakdown</h4>
+                      <ul className="mt-3 space-y-2 text-slate-600">
+                        {Object.entries(channelMix).map(([channelId, weight]) => {
+                          const channel = channels.find((c) => c.id === channelId)!;
+                          return (
+                            <li key={channelId} className="flex items-center justify-between">
+                              <span>{channel.name}</span>
+                              <span>
+                                {percentFormatter.format(weight)} • {currencyFormatter.format(channel.cac * weight)}
+                              </span>
+                            </li>
+                          );
+                        })}
+                        <li className="flex items-center justify-between font-medium text-slate-700">
+                          <span>Promo + device + execution</span>
+                          <span>{currencyFormatter.format(promoDeviceExecution)}</span>
+                        </li>
+                        <li className="flex items-center justify-between font-semibold text-slate-900">
+                          <span>Total CAC / subscriber</span>
+                          <span>{currencyFormatter.format(heroSummary.cacPerSubscriber)}</span>
+                        </li>
+                        <li className="flex items-center justify-between font-semibold text-primary">
+                          <span>Cohort CAC (net adds)</span>
+                          <span>{currencyFormatter.format(heroSummary.cac)}</span>
+                        </li>
+                      </ul>
+                    </div>
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+                      <h4 className="text-sm font-semibold text-slate-900">Contribution timeline</h4>
+                      <div className="h-48">
+                        <ResponsiveContainer>
+                          <LineChart data={contributionSeries}>
+                            <XAxis dataKey="month" tickFormatter={(value) => `M${value}`} />
+                            <YAxis tickFormatter={(value) => `$${value.toFixed(0)}`} />
+                            <Tooltip formatter={(value: number) => currencyFormatter.format(value)} labelFormatter={(label) => `Month ${label}`} />
+                            <Line type="monotone" dataKey="contribution" stroke="#1f7aec" strokeWidth={2} dot={false} />
+                          </LineChart>
+                        </ResponsiveContainer>
+                      </div>
+                      <p className="mt-2 text-xs text-slate-500">Contribution includes gross margin less servicing and device amortization.</p>
+                    </div>
+                  </div>
+                  <div className="mt-6 flex justify-end">
+                    <button onClick={() => setAssumptionModal(false)} className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm">
+                      Close
+                    </button>
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition.Root>
+    </div>
+  );
+};

--- a/src/app/routes/SegmentStudio.tsx
+++ b/src/app/routes/SegmentStudio.tsx
@@ -1,0 +1,344 @@
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Dialog, Transition } from '@headlessui/react';
+import { ArrowUpRight, ChevronRight, Sparkles } from 'lucide-react';
+import { channels, offerArchetypes } from '../../data/seeds';
+import { InfoPopover } from '../../components/InfoPopover';
+import { currencyFormatter, formatPayback, percentFormatter } from '../../lib/format';
+import { getOfferById, runCohort } from '../../sim/tinySim';
+import { useActiveSegment, useGlobalStore } from '../../store/globalStore';
+import { buildRecommendation, generateMicroSegments, normaliseMix } from '../../lib/microSegments';
+
+interface MicroSummary {
+  micro: ReturnType<typeof generateMicroSegments>[number];
+  summary: ReturnType<typeof runCohort>;
+}
+
+export const SegmentStudioRoute = () => {
+  const activeSegment = useActiveSegment();
+  const selectedMicroIds = useGlobalStore((state) => state.selectedMicroSegmentIds);
+  const toggleMicroSegment = useGlobalStore((state) => state.toggleMicroSegment);
+  const recommendations = useGlobalStore((state) => state.recommendationsByMicroSegment);
+  const setRecommendation = useGlobalStore((state) => state.setRecommendationsForMicro);
+  const setInfoPanel = useGlobalStore((state) => state.setInfoPanel);
+  const [showGuard, setShowGuard] = useState(false);
+
+  useEffect(() => {
+    if (!activeSegment) {
+      setShowGuard(true);
+    }
+  }, [activeSegment]);
+
+  const micros = useMemo(() => generateMicroSegments(activeSegment), [activeSegment]);
+
+  useEffect(() => {
+    micros.forEach((micro) => {
+      if (!recommendations[micro.id]) {
+        setRecommendation(micro.id, buildRecommendation(micro));
+      }
+    });
+  }, [micros, recommendations, setRecommendation]);
+
+  const microSummaries: MicroSummary[] = micros.map((micro) => {
+    const recommendation = recommendations[micro.id];
+    const offer = getOfferById(recommendation?.offerArchetypeId ?? micro.defaultOfferId);
+    const mix = normaliseMix(recommendation?.channelMix ?? micro.defaultChannelMix);
+    const summary = runCohort({
+      segment: {
+        id: micro.id,
+        name: micro.name,
+        size: micro.size,
+        priceSensitivity: micro.priceSensitivity,
+        valueSensitivity: micro.valueSensitivity,
+        growthRate: activeSegment.growthRate
+      },
+      offer,
+      channelMix: mix
+    });
+    return { micro, summary };
+  });
+
+  const selectedSummaries = microSummaries.filter((entry) => selectedMicroIds.includes(entry.micro.id));
+  const aggregate = selectedSummaries.reduce(
+    (acc, entry) => {
+      acc.size += entry.micro.size;
+      acc.netAdds += entry.summary.netAdds;
+      acc.grossMargin += entry.summary.grossMargin12Mo;
+      const payback = parseInt(entry.summary.paybackMonths, 10);
+      if (!Number.isNaN(payback)) acc.paybackMonths.push(payback);
+      return acc;
+    },
+    { size: 0, netAdds: 0, grossMargin: 0, paybackMonths: [] as number[] }
+  );
+  const blendedPayback = aggregate.paybackMonths.length
+    ? `${Math.round(aggregate.paybackMonths.reduce((sum, value) => sum + value, 0) / aggregate.paybackMonths.length)} mo`
+    : '—';
+
+  const handleChannelAdjust = (microId: string, channelId: string, weight: number) => {
+    const baseMicro = micros.find((micro) => micro.id === microId);
+    if (!baseMicro) return;
+    const current = recommendations[microId] ?? buildRecommendation(baseMicro);
+    const updatedMix = normaliseMix({ ...current.channelMix, [channelId]: weight });
+    const offer = getOfferById(current.offerArchetypeId);
+    const summary = runCohort({
+      segment: {
+        id: baseMicro.id,
+        name: baseMicro.name,
+        size: baseMicro.size,
+        priceSensitivity: baseMicro.priceSensitivity,
+        valueSensitivity: baseMicro.valueSensitivity,
+        growthRate: activeSegment.growthRate
+      },
+      offer,
+      channelMix: updatedMix
+    });
+    setRecommendation(baseMicro.id, {
+      ...current,
+      channelMix: updatedMix,
+      expected: {
+        paybackMonths: summary.paybackMonths,
+        grossMargin12Mo: summary.grossMargin12Mo,
+        netAdds: summary.netAdds
+      }
+    });
+  };
+
+  const handleOfferSwap = (microId: string, offerId: string) => {
+    const baseMicro = micros.find((micro) => micro.id === microId);
+    if (!baseMicro) return;
+    const current = recommendations[microId] ?? buildRecommendation(baseMicro);
+    const offer = getOfferById(offerId);
+    const updatedMix = normaliseMix(current.channelMix);
+    const summary = runCohort({
+      segment: {
+        id: baseMicro.id,
+        name: baseMicro.name,
+        size: baseMicro.size,
+        priceSensitivity: baseMicro.priceSensitivity,
+        valueSensitivity: baseMicro.valueSensitivity,
+        growthRate: activeSegment.growthRate
+      },
+      offer,
+      channelMix: updatedMix
+    });
+    setRecommendation(baseMicro.id, {
+      ...current,
+      offerArchetypeId: offer.id,
+      channelMix: updatedMix,
+      expected: {
+        paybackMonths: summary.paybackMonths,
+        grossMargin12Mo: summary.grossMargin12Mo,
+        netAdds: summary.netAdds
+      }
+    });
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+      <div className="space-y-6">
+        <header className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-slate-900">Micro-segment gallery</h1>
+            <p className="text-sm text-slate-600">Auto-clustered personas derived from {activeSegment.name}. Toggle to curate your campaign audience.</p>
+          </div>
+          <InfoPopover
+            title="Micro-segments"
+            plainDescription="AI clustering of the selected macro segment to surface actionable cohorts."
+            primarySourceHint="Synth behaviour + usage"
+          />
+        </header>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {microSummaries.map(({ micro, summary }) => {
+            const recommendation = recommendations[micro.id];
+            return (
+              <div
+                key={micro.id}
+                className={`flex h-full flex-col rounded-3xl border bg-white p-5 shadow-sm transition focus-within:ring-2 focus-within:ring-primary ${
+                  selectedMicroIds.includes(micro.id) ? 'border-primary shadow-md' : 'border-slate-200'
+                }`}
+                tabIndex={0}
+                onFocus={() =>
+                  setInfoPanel({
+                    title: micro.name,
+                    description: micro.traits.join(' • '),
+                    hint: 'Synth cluster rationale'
+                  })
+                }
+              >
+                <div className="flex items-start justify-between">
+                  <div>
+                    <h3 className="text-lg font-semibold text-slate-900">{micro.name}</h3>
+                    <p className="text-sm text-slate-500">{micro.traits.join(' • ')}</p>
+                  </div>
+                  <button
+                    className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+                      selectedMicroIds.includes(micro.id)
+                        ? 'border-primary bg-primary text-white'
+                        : 'border-slate-300 text-slate-600 hover:border-primary hover:text-primary'
+                    }`}
+                    onClick={() => toggleMicroSegment(micro.id)}
+                  >
+                    {selectedMicroIds.includes(micro.id) ? 'Targeted' : 'Target'}
+                  </button>
+                </div>
+                <dl className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-600">
+                  <div>
+                    <dt className="font-medium text-slate-500">Size</dt>
+                    <dd className="text-base font-semibold text-slate-900">{micro.size.toLocaleString()}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-slate-500">Net adds</dt>
+                    <dd className="text-base font-semibold text-slate-900">{summary.netAdds.toLocaleString()}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-slate-500">Payback</dt>
+                    <dd className="text-base font-semibold text-slate-900">{formatPayback(summary.paybackMonths)}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-slate-500">12-mo GM</dt>
+                    <dd className="text-base font-semibold text-slate-900">{currencyFormatter.format(summary.grossMargin12Mo)}</dd>
+                  </div>
+                </dl>
+                <div className="mt-4 rounded-2xl bg-slate-50 p-4 text-xs text-slate-500">
+                  <p className="font-semibold text-slate-600">Channel blend</p>
+                  <ul className="mt-2 space-y-1">
+                    {Object.entries(recommendation?.channelMix ?? micro.defaultChannelMix).map(([channelId, weight]) => {
+                      const channel = channels.find((c) => c.id === channelId)!;
+                      return (
+                        <li key={channelId} className="flex items-center justify-between">
+                          <span>{channel.name}</span>
+                          <span>{percentFormatter.format(weight)}</span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="sticky bottom-4 z-10 rounded-3xl border border-slate-200 bg-white p-5 shadow-lg">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Selection roll-up</h3>
+              <p className="text-lg font-semibold text-slate-900">{selectedMicroIds.length ? `${selectedMicroIds.length} micro-segments targeted` : 'Pick micro-segments to build a plan'}</p>
+            </div>
+            <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600">
+              <span>Reachable size {aggregate.size.toLocaleString()}</span>
+              <span>Blended payback {blendedPayback}</span>
+              <span>12-mo GM {currencyFormatter.format(aggregate.grossMargin)}</span>
+              <span>Net adds {aggregate.netAdds.toLocaleString()}</span>
+            </div>
+            <Link
+              to="/campaign-designer"
+              className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold ${
+                selectedMicroIds.length
+                  ? 'bg-primary text-white shadow-sm'
+                  : 'bg-slate-200 text-slate-500 pointer-events-none'
+              }`}
+            >
+              Continue to campaign <ChevronRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <aside className="space-y-4">
+        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold text-slate-900">AI activation kit</h2>
+            <Sparkles className="h-4 w-4 text-primary" />
+          </div>
+          <p className="mt-1 text-sm text-slate-600">Adjust channel weights or swap offers to see updated KPIs instantly.</p>
+        </div>
+        {selectedSummaries.map(({ micro }) => {
+          const recommendation = recommendations[micro.id] ?? buildRecommendation(micro);
+          return (
+            <div key={micro.id} className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-base font-semibold text-slate-900">{micro.name}</h3>
+                  <p className="text-sm text-slate-500">{recommendation.rationale.join(' • ')}</p>
+                </div>
+                <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">Live</span>
+              </div>
+              <div className="mt-4 space-y-3 text-sm text-slate-600">
+                <label className="flex flex-col gap-2">
+                  <span className="font-medium text-slate-600">Offer archetype</span>
+                  <select
+                    value={recommendation.offerArchetypeId}
+                    onChange={(event) => handleOfferSwap(micro.id, event.target.value)}
+                    className="rounded-xl border border-slate-300 px-3 py-2"
+                  >
+                    {offerArchetypes.map((offer) => (
+                      <option key={offer.id} value={offer.id}>
+                        {offer.name} — {currencyFormatter.format(offer.monthlyPrice)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <div>
+                  <p className="font-medium text-slate-600">Channel weights</p>
+                  <div className="mt-2 space-y-2">
+                    {channels.map((channel) => (
+                      <label key={channel.id} className="flex flex-col gap-1 text-xs">
+                        <span className="flex items-center justify-between text-sm text-slate-600">
+                          {channel.name}
+                          <span>{percentFormatter.format(recommendation.channelMix[channel.id] ?? 0)}</span>
+                        </span>
+                        <input
+                          type="range"
+                          min={5}
+                          max={80}
+                          step={5}
+                          value={Math.round((recommendation.channelMix[channel.id] ?? 0) * 100)}
+                          onChange={(event) => handleChannelAdjust(micro.id, channel.id, Number(event.target.value) / 100)}
+                        />
+                      </label>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <p className="font-medium text-slate-600">Creative tone</p>
+                  <ul className="mt-2 list-disc pl-5 text-xs text-slate-500">
+                    {recommendation.creativeTone.map((line, index) => (
+                      <li key={index}>{line}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="rounded-2xl bg-slate-50 p-4 text-xs text-slate-500">
+                  <p className="font-semibold text-slate-600">Expected KPIs</p>
+                  <ul className="mt-2 space-y-1">
+                    <li>Payback {formatPayback(recommendation.expected.paybackMonths)}</li>
+                    <li>12-mo GM {currencyFormatter.format(recommendation.expected.grossMargin12Mo)}</li>
+                    <li>Net adds {recommendation.expected.netAdds.toLocaleString()}</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </aside>
+
+      <Transition.Root show={showGuard} as={Fragment}>
+        <Dialog as="div" className="relative z-50" onClose={setShowGuard}>
+          <Transition.Child as={Fragment} enter="ease-out duration-150" enterFrom="opacity-0" enterTo="opacity-100" leave="ease-in duration-150" leaveFrom="opacity-100" leaveTo="opacity-0">
+            <div className="fixed inset-0 bg-slate-900/50" />
+          </Transition.Child>
+          <div className="fixed inset-0 flex items-center justify-center p-6">
+            <Transition.Child as={Fragment} enter="ease-out duration-150" enterFrom="opacity-0 translate-y-3" enterTo="opacity-100 translate-y-0" leave="ease-in duration-100" leaveFrom="opacity-100 translate-y-0" leaveTo="opacity-0 translate-y-3">
+              <Dialog.Panel className="w-full max-w-md rounded-3xl border border-slate-200 bg-white p-6 shadow-xl">
+                <Dialog.Title className="text-lg font-semibold text-slate-900">Pick a segment first</Dialog.Title>
+                <p className="mt-2 text-sm text-slate-600">Head back to Market Radar to set an active segment before shaping micro-segments.</p>
+                <Link to="/market-radar" className="mt-6 inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm">
+                  Go to Market Radar <ArrowUpRight className="h-4 w-4" />
+                </Link>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </Dialog>
+      </Transition.Root>
+    </div>
+  );
+};

--- a/src/components/CompareDrawer.tsx
+++ b/src/components/CompareDrawer.tsx
@@ -1,0 +1,92 @@
+import { Fragment } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { X } from 'lucide-react';
+import { type Segment } from '../data/seeds';
+import { currencyFormatter, formatPayback } from '../lib/format';
+import { summariseCohort } from '../sim/tinySim';
+
+interface CompareDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  segments: Segment[];
+}
+
+export const CompareDrawer = ({ open, onClose, segments }: CompareDrawerProps) => {
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-40" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-slate-900/40" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-hidden">
+          <div className="absolute inset-y-0 right-0 flex max-w-full pl-10">
+            <Transition.Child
+              as={Fragment}
+              enter="transform transition ease-in-out duration-300"
+              enterFrom="translate-x-full"
+              enterTo="translate-x-0"
+              leave="transform transition ease-in-out duration-200"
+              leaveFrom="translate-x-0"
+              leaveTo="translate-x-full"
+            >
+              <Dialog.Panel className="pointer-events-auto w-screen max-w-3xl bg-white shadow-xl">
+                <div className="flex h-full flex-col">
+                  <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+                    <Dialog.Title className="text-lg font-semibold text-slate-900">Compare segments</Dialog.Title>
+                    <button onClick={onClose} className="rounded-full p-2 text-slate-500 hover:bg-slate-100" aria-label="Close">
+                      <X className="h-5 w-5" />
+                    </button>
+                  </div>
+                  <div className="flex-1 overflow-y-auto px-6 py-6">
+                    <div className="grid gap-6">
+                      {segments.map((segment) => {
+                        const summary = summariseCohort(segment);
+                        return (
+                          <div key={segment.id} className="rounded-2xl border border-slate-200 bg-slate-50/60 p-5">
+                            <div className="flex items-center justify-between">
+                              <div>
+                                <h3 className="text-lg font-semibold text-slate-900">{segment.name}</h3>
+                                <p className="text-sm text-slate-600">{segment.notes}</p>
+                              </div>
+                              <div className="text-right text-sm text-slate-500">
+                                <p>Size: {segment.size.toLocaleString()}</p>
+                                <p>Growth: {(segment.growthRate * 100).toFixed(1)}%</p>
+                              </div>
+                            </div>
+                            <dl className="mt-4 grid grid-cols-3 gap-4 text-sm">
+                              <div className="rounded-xl bg-white p-4 shadow-inner">
+                                <dt className="font-medium text-slate-500">CAC Payback</dt>
+                                <dd className="mt-1 text-lg font-semibold text-slate-900">{formatPayback(summary.paybackMonths)}</dd>
+                              </div>
+                              <div className="rounded-xl bg-white p-4 shadow-inner">
+                                <dt className="font-medium text-slate-500">12-mo Margin</dt>
+                                <dd className="mt-1 text-lg font-semibold text-slate-900">{currencyFormatter.format(summary.grossMargin12Mo)}</dd>
+                              </div>
+                              <div className="rounded-xl bg-white p-4 shadow-inner">
+                                <dt className="font-medium text-slate-500">Net Adds est.</dt>
+                                <dd className="mt-1 text-lg font-semibold text-slate-900">{summary.netAdds.toLocaleString()}</dd>
+                              </div>
+                            </dl>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+};

--- a/src/components/CompetitorHeatmap.tsx
+++ b/src/components/CompetitorHeatmap.tsx
@@ -1,0 +1,61 @@
+import { ResponsiveContainer, Scatter, ScatterChart, Tooltip, XAxis, YAxis, ZAxis, CartesianGrid, Cell } from 'recharts';
+import { competitors } from '../data/seeds';
+import { InfoPopover } from './InfoPopover';
+
+const data = competitors.map((competitor) => ({
+  name: competitor.name,
+  valueScore: competitor.valueScore,
+  price: competitor.basePrice - competitor.promoDepth / 2,
+  composite: Math.round((competitor.networkScore + competitor.coverageScore) / 2)
+}));
+
+const colorScale = (value: number) => {
+  if (value > 85) return '#2563eb';
+  if (value > 75) return '#3b82f6';
+  if (value > 65) return '#60a5fa';
+  return '#93c5fd';
+};
+
+export const CompetitorHeatmap = () => {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">Price vs. value perception</h3>
+          <p className="text-sm text-slate-500">Higher value score indicates better perceived experience.</p>
+        </div>
+        <InfoPopover
+          title="Competitive Heatmap"
+          plainDescription="Relative price vs. perceived value among leading competitors."
+          primarySourceHint="Synth sentiment + pricing"
+        />
+      </div>
+      <div className="h-64">
+        <ResponsiveContainer>
+          <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis type="number" dataKey="valueScore" name="Value score" domain={[60, 95]} tickFormatter={(value) => `${value}`}
+              label={{ value: 'Perceived value ↑', position: 'insideBottom', offset: -10 }}
+            />
+            <YAxis type="number" dataKey="price" name="Effective price" domain={[45, 95]} tickFormatter={(value) => `$${value}`}
+              label={{ value: 'Effective price ($)', angle: -90, position: 'insideLeft' }}
+            />
+            <ZAxis type="number" dataKey="composite" range={[120, 400]} name="Network + coverage" />
+            <Tooltip cursor={{ strokeDasharray: '4 4' }} formatter={(value: number, name: string, payload) => {
+              if (name === 'price') return [`$${value.toFixed(0)}`, 'Effective price'];
+              if (name === 'valueScore') return [`${value}`, 'Value score'];
+              if (name === 'composite') return [`${value}`, 'Network + coverage'];
+              return [value, name];
+            }} />
+            <Scatter name="Competitors" data={data} shape="circle">
+              {data.map((entry) => (
+                <Cell key={entry.name} fill={colorScale(entry.composite)} />
+              ))}
+            </Scatter>
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="mt-3 text-xs text-slate-500">Estimates from synthetic data.</p>
+    </div>
+  );
+};

--- a/src/components/InfoPopover.tsx
+++ b/src/components/InfoPopover.tsx
@@ -1,0 +1,46 @@
+import * as Popover from '@radix-ui/react-popover';
+import { InfoIcon } from 'lucide-react';
+import { type ReactNode } from 'react';
+
+interface InfoPopoverProps {
+  title: string;
+  plainDescription: string;
+  primarySourceHint: string;
+  children?: ReactNode;
+}
+
+export const InfoPopover = ({ title, plainDescription, primarySourceHint, children }: InfoPopoverProps) => {
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          aria-label={`Info: ${title}`}
+          className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-600 transition hover:bg-slate-100 focus-visible:ring-offset-0"
+        >
+          <InfoIcon className="h-3.5 w-3.5" />
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          sideOffset={8}
+          className="z-50 max-w-xs rounded-xl border border-slate-200 bg-white p-4 text-sm shadow-xl focus:outline-none"
+        >
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 rounded-md bg-primary/10 p-1 text-primary">
+              <InfoIcon className="h-4 w-4" />
+            </div>
+            <div>
+              <h4 className="font-semibold text-slate-900">{title}</h4>
+              <p className="mt-1 text-slate-600">{plainDescription}</p>
+              {children ? <div className="mt-2 text-slate-600">{children}</div> : null}
+              <p className="mt-3 text-xs font-medium uppercase tracking-wide text-slate-500">Primary data source (est.)</p>
+              <p className="text-xs text-slate-600">{primarySourceHint}</p>
+            </div>
+          </div>
+          <Popover.Arrow className="fill-white" />
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+};

--- a/src/components/KpiCard.tsx
+++ b/src/components/KpiCard.tsx
@@ -1,0 +1,39 @@
+import { ArrowDownRight, ArrowUpRight } from 'lucide-react';
+import { InfoPopover } from './InfoPopover';
+
+interface KpiCardProps {
+  title: string;
+  value: string;
+  deltaLabel?: string;
+  trend?: 'up' | 'down' | 'flat';
+  info: { description: string; source: string; formula?: string };
+  onFocus?: () => void;
+}
+
+export const KpiCard = ({ title, value, deltaLabel, trend = 'flat', info, onFocus }: KpiCardProps) => {
+  return (
+    <div
+      tabIndex={0}
+      onFocus={onFocus}
+      onMouseEnter={onFocus}
+      className="group relative flex min-h-[140px] flex-col justify-between rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition focus-visible:ring-2 focus-visible:ring-primary"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{title}</p>
+          <p className="mt-3 text-3xl font-semibold text-slate-900">{value}</p>
+        </div>
+        <InfoPopover title={title} plainDescription={info.description} primarySourceHint={info.source}>
+          {info.formula ? <p className="text-xs text-slate-500">Formula: {info.formula}</p> : null}
+        </InfoPopover>
+      </div>
+      {deltaLabel ? (
+        <div className="mt-6 flex items-center gap-2 text-sm text-slate-600">
+          {trend === 'up' ? <ArrowUpRight className="h-4 w-4 text-emerald-500" /> : null}
+          {trend === 'down' ? <ArrowDownRight className="h-4 w-4 text-rose-500" /> : null}
+          <span>{deltaLabel}</span>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/src/components/MigrationMatrix.tsx
+++ b/src/components/MigrationMatrix.tsx
@@ -1,0 +1,72 @@
+import { migrationMatrix } from '../data/seeds';
+import { InfoPopover } from './InfoPopover';
+
+const actors = ['Us', 'AlphaMobile', 'BetaTel', 'CableCoMobile', 'MagentaNet'];
+
+const buildMatrix = () => {
+  const matrix: Record<string, Record<string, number>> = {};
+  for (const from of actors) {
+    matrix[from] = {};
+    for (const to of actors) {
+      matrix[from][to] = 0;
+    }
+  }
+  migrationMatrix.forEach((flow) => {
+    if (!matrix[flow.from]) {
+      matrix[flow.from] = {} as Record<string, number>;
+    }
+    matrix[flow.from][flow.to] = flow.value;
+  });
+  return matrix;
+};
+
+const matrix = buildMatrix();
+
+export const MigrationMatrix = () => {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">Migration flows (last 90 days)</h3>
+          <p className="text-sm text-slate-500">Share of switchers between leading brands.</p>
+        </div>
+        <InfoPopover
+          title="Migration Matrix"
+          plainDescription="Estimated share of recent switchers flowing between us and top competitors."
+          primarySourceHint="Synth churn + porting signals"
+        />
+      </div>
+      <div className="overflow-auto">
+        <table className="min-w-full border-separate border-spacing-0 text-sm">
+          <thead>
+            <tr>
+              <th scope="col" className="sticky left-0 z-10 bg-white px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                From/To
+              </th>
+              {actors.map((actor) => (
+                <th key={actor} scope="col" className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  {actor}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {actors.map((from) => (
+              <tr key={from} className="even:bg-slate-50/60">
+                <th scope="row" className="sticky left-0 z-10 bg-white px-4 py-2 text-left font-medium text-slate-700">
+                  {from}
+                </th>
+                {actors.map((to) => (
+                  <td key={`${from}-${to}`} className="px-4 py-2 text-slate-600">
+                    {from === to ? '—' : `${(matrix[from]?.[to] ?? 0) * 100}%`}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-3 text-xs text-slate-500">Estimates from synthetic data.</p>
+    </div>
+  );
+};

--- a/src/components/SegmentCard.tsx
+++ b/src/components/SegmentCard.tsx
@@ -1,0 +1,81 @@
+import { CheckCircle2, Sparkles, Star } from 'lucide-react';
+import { useMemo } from 'react';
+import { type Segment } from '../data/seeds';
+import { formatPayback, currencyFormatter } from '../lib/format';
+import { summariseCohort } from '../sim/tinySim';
+
+interface SegmentCardProps {
+  segment: Segment;
+  active: boolean;
+  comparing: boolean;
+  onSelect: () => void;
+  onToggleCompare: (checked: boolean) => void;
+}
+
+export const SegmentCard = ({ segment, active, comparing, onSelect, onToggleCompare }: SegmentCardProps) => {
+  const summary = useMemo(() => summariseCohort(segment), [segment]);
+
+  return (
+    <article
+      tabIndex={0}
+      role="button"
+      aria-pressed={active}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
+      className={`flex h-full min-w-[340px] snap-center flex-col rounded-3xl border bg-white p-6 shadow-sm transition focus-visible:ring-2 focus-visible:ring-primary ${
+        active ? 'border-primary/70 shadow-md' : 'border-transparent hover:border-primary/40'
+      }`}
+    >
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">{segment.name}</h3>
+          <p className="text-sm text-slate-500">{segment.notes}</p>
+        </div>
+        {active ? <CheckCircle2 className="h-6 w-6 text-primary" aria-hidden /> : <Sparkles className="h-6 w-6 text-slate-300" aria-hidden />}
+      </header>
+
+      <div className="mt-5 grid grid-cols-2 gap-4 text-sm">
+        <div>
+          <p className="font-medium text-slate-600">Segment size</p>
+          <p className="text-lg font-semibold text-slate-900">{segment.size.toLocaleString()}</p>
+        </div>
+        <div>
+          <p className="font-medium text-slate-600">Growth rate</p>
+          <p className="text-lg font-semibold text-slate-900">{(segment.growthRate * 100).toFixed(1)}%</p>
+        </div>
+        <div>
+          <p className="font-medium text-slate-600">CAC payback</p>
+          <p className="text-lg font-semibold text-slate-900">{formatPayback(summary.paybackMonths)}</p>
+        </div>
+        <div>
+          <p className="font-medium text-slate-600">12-mo gross margin</p>
+          <p className="text-lg font-semibold text-slate-900">{currencyFormatter.format(summary.grossMargin12Mo)}</p>
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between text-sm text-slate-600">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+            checked={comparing}
+            onChange={(event) => {
+              event.stopPropagation();
+              onToggleCompare(event.target.checked);
+            }}
+            onClick={(event) => event.stopPropagation()}
+          />
+          Compare
+        </label>
+        <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+          <Star className="h-3 w-3" /> KPI ready
+        </span>
+      </div>
+    </article>
+  );
+};

--- a/src/data/seeds.ts
+++ b/src/data/seeds.ts
@@ -1,0 +1,318 @@
+export interface Segment {
+  id: string;
+  name: string;
+  size: number;
+  growthRate: number;
+  priceSensitivity: number;
+  valueSensitivity: number;
+  regionMix: Record<string, number>;
+  demographics: {
+    income: 'low' | 'mid' | 'high';
+    age: 'youth' | 'adult' | 'senior';
+    household: 'single' | 'family';
+  };
+  notes: string;
+  defaultOfferId: string;
+  defaultChannelMix: Record<string, number>;
+}
+
+export interface Competitor {
+  id: string;
+  name: string;
+  basePrice: number;
+  promoStyle: string;
+  networkScore: number;
+  coverageScore: number;
+  valueScore: number;
+  churnInflow: number;
+  churnOutflow: number;
+  bundleFlag: boolean;
+  promoDepth: number;
+}
+
+export interface OfferArchetype {
+  id: string;
+  name: string;
+  description: string;
+  monthlyPrice: number;
+  promoMonths: number;
+  promoValue: number;
+  deviceSubsidy: number;
+  bundleFlag: boolean;
+  channelMixDefaults: Record<string, number>;
+}
+
+export interface Channel {
+  id: string;
+  name: string;
+  cac: number;
+  convCurveParams: {
+    reach: number;
+    efficiency: number;
+  };
+}
+
+export interface Assumptions {
+  grossMarginRate: number;
+  servicingCostPerSubMo: number;
+  deviceSubsidyAmortMo: number;
+  executionCost: number;
+}
+
+export const segments: Segment[] = [
+  {
+    id: 'seg-value-seekers',
+    name: 'Value Seekers',
+    size: 420000,
+    growthRate: 0.08,
+    priceSensitivity: 0.82,
+    valueSensitivity: 0.64,
+    regionMix: { urban: 0.42, suburban: 0.33, rural: 0.25 },
+    demographics: { income: 'low', age: 'adult', household: 'family' },
+    notes: 'Large prepaid skew, hunt for discounts but respond to bundles.',
+    defaultOfferId: 'offer-value-bundle',
+    defaultChannelMix: { 'channel-paid-social': 0.35, 'channel-search': 0.35, 'channel-retail': 0.2, 'channel-field': 0.1 }
+  },
+  {
+    id: 'seg-premium-network',
+    name: 'Premium Network Loyalists',
+    size: 250000,
+    growthRate: 0.05,
+    priceSensitivity: 0.38,
+    valueSensitivity: 0.74,
+    regionMix: { urban: 0.55, suburban: 0.35, rural: 0.1 },
+    demographics: { income: 'high', age: 'adult', household: 'single' },
+    notes: 'Expect flawless coverage and premium support; low churn but high ARPU.',
+    defaultOfferId: 'offer-price-lock',
+    defaultChannelMix: { 'channel-search': 0.25, 'channel-retail': 0.3, 'channel-field': 0.2, 'channel-paid-social': 0.25 }
+  },
+  {
+    id: 'seg-rural-seniors',
+    name: 'Rural Seniors',
+    size: 150000,
+    growthRate: 0.02,
+    priceSensitivity: 0.55,
+    valueSensitivity: 0.48,
+    regionMix: { urban: 0.08, suburban: 0.22, rural: 0.7 },
+    demographics: { income: 'mid', age: 'senior', household: 'single' },
+    notes: 'Need reliability and assisted onboarding; limited data usage.',
+    defaultOfferId: 'offer-device-boost',
+    defaultChannelMix: { 'channel-field': 0.35, 'channel-retail': 0.4, 'channel-paid-social': 0.1, 'channel-search': 0.15 }
+  },
+  {
+    id: 'seg-urban-streamers',
+    name: 'Urban Streamers',
+    size: 310000,
+    growthRate: 0.11,
+    priceSensitivity: 0.58,
+    valueSensitivity: 0.86,
+    regionMix: { urban: 0.68, suburban: 0.27, rural: 0.05 },
+    demographics: { income: 'mid', age: 'youth', household: 'single' },
+    notes: 'Heavy data + entertainment usage; respond to bundles and speed.',
+    defaultOfferId: 'offer-streamer-pack',
+    defaultChannelMix: { 'channel-paid-social': 0.4, 'channel-search': 0.3, 'channel-retail': 0.2, 'channel-field': 0.1 }
+  },
+  {
+    id: 'seg-family-bundlers',
+    name: 'Family Bundlers',
+    size: 380000,
+    growthRate: 0.07,
+    priceSensitivity: 0.6,
+    valueSensitivity: 0.79,
+    regionMix: { urban: 0.32, suburban: 0.46, rural: 0.22 },
+    demographics: { income: 'mid', age: 'adult', household: 'family' },
+    notes: 'Multiline households balancing price with perks and parental controls.',
+    defaultOfferId: 'offer-value-bundle',
+    defaultChannelMix: { 'channel-retail': 0.32, 'channel-paid-social': 0.28, 'channel-search': 0.25, 'channel-field': 0.15 }
+  },
+  {
+    id: 'seg-switch-prepaid',
+    name: 'Switch-Prone Prepaid',
+    size: 270000,
+    growthRate: 0.09,
+    priceSensitivity: 0.9,
+    valueSensitivity: 0.52,
+    regionMix: { urban: 0.5, suburban: 0.3, rural: 0.2 },
+    demographics: { income: 'low', age: 'adult', household: 'single' },
+    notes: 'Churn-heavy prepaid shoppers; move for promos and device deals.',
+    defaultOfferId: 'offer-device-boost',
+    defaultChannelMix: { 'channel-paid-social': 0.4, 'channel-search': 0.3, 'channel-retail': 0.2, 'channel-field': 0.1 }
+  }
+];
+
+export const offerArchetypes: OfferArchetype[] = [
+  {
+    id: 'offer-value-bundle',
+    name: 'Value Bundle',
+    description: '2-line bundle with streaming perk and $15/mo promo for 3 months.',
+    monthlyPrice: 65,
+    promoMonths: 3,
+    promoValue: 15,
+    deviceSubsidy: 120,
+    bundleFlag: true,
+    channelMixDefaults: { 'channel-paid-social': 0.35, 'channel-search': 0.3, 'channel-retail': 0.25, 'channel-field': 0.1 }
+  },
+  {
+    id: 'offer-device-boost',
+    name: 'Device Boost',
+    description: '$200 device credit with 24-month installment.',
+    monthlyPrice: 75,
+    promoMonths: 2,
+    promoValue: 10,
+    deviceSubsidy: 200,
+    bundleFlag: false,
+    channelMixDefaults: { 'channel-retail': 0.38, 'channel-field': 0.24, 'channel-search': 0.2, 'channel-paid-social': 0.18 }
+  },
+  {
+    id: 'offer-price-lock',
+    name: 'Price-Lock 12',
+    description: 'Premium unlimited with price locked for 12 months.',
+    monthlyPrice: 90,
+    promoMonths: 1,
+    promoValue: 20,
+    deviceSubsidy: 150,
+    bundleFlag: false,
+    channelMixDefaults: { 'channel-retail': 0.3, 'channel-field': 0.25, 'channel-search': 0.25, 'channel-paid-social': 0.2 }
+  },
+  {
+    id: 'offer-streamer-pack',
+    name: 'Streamer Pack',
+    description: 'Unlimited premium data with 3 streaming services included.',
+    monthlyPrice: 85,
+    promoMonths: 3,
+    promoValue: 18,
+    deviceSubsidy: 160,
+    bundleFlag: true,
+    channelMixDefaults: { 'channel-paid-social': 0.42, 'channel-search': 0.28, 'channel-retail': 0.18, 'channel-field': 0.12 }
+  }
+];
+
+export const channels: Channel[] = [
+  {
+    id: 'channel-paid-social',
+    name: 'Paid Social',
+    cac: 85,
+    convCurveParams: { reach: 0.42, efficiency: 0.65 }
+  },
+  {
+    id: 'channel-search',
+    name: 'Search',
+    cac: 65,
+    convCurveParams: { reach: 0.36, efficiency: 0.72 }
+  },
+  {
+    id: 'channel-retail',
+    name: 'Retail',
+    cac: 140,
+    convCurveParams: { reach: 0.28, efficiency: 0.58 }
+  },
+  {
+    id: 'channel-field',
+    name: 'Field',
+    cac: 180,
+    convCurveParams: { reach: 0.22, efficiency: 0.55 }
+  }
+];
+
+export const assumptions: Assumptions = {
+  grossMarginRate: 0.55,
+  servicingCostPerSubMo: 12,
+  deviceSubsidyAmortMo: 12,
+  executionCost: 20
+};
+
+export const competitors: Competitor[] = [
+  {
+    id: 'comp-alpha',
+    name: 'AlphaMobile',
+    basePrice: 75,
+    promoStyle: 'Flash promo, $200 device credit',
+    networkScore: 82,
+    coverageScore: 85,
+    valueScore: 74,
+    churnInflow: 0.28,
+    churnOutflow: 0.22,
+    bundleFlag: true,
+    promoDepth: 18
+  },
+  {
+    id: 'comp-beta',
+    name: 'BetaTel',
+    basePrice: 68,
+    promoStyle: 'Always-on 2 for $120',
+    networkScore: 74,
+    coverageScore: 70,
+    valueScore: 77,
+    churnInflow: 0.21,
+    churnOutflow: 0.27,
+    bundleFlag: false,
+    promoDepth: 12
+  },
+  {
+    id: 'comp-cableco',
+    name: 'CableCoMobile',
+    basePrice: 60,
+    promoStyle: 'Bundle with home internet',
+    networkScore: 68,
+    coverageScore: 66,
+    valueScore: 71,
+    churnInflow: 0.26,
+    churnOutflow: 0.24,
+    bundleFlag: true,
+    promoDepth: 20
+  },
+  {
+    id: 'comp-magenta',
+    name: 'MagentaNet',
+    basePrice: 80,
+    promoStyle: 'VIP perks + streaming',
+    networkScore: 88,
+    coverageScore: 83,
+    valueScore: 81,
+    churnInflow: 0.31,
+    churnOutflow: 0.19,
+    bundleFlag: true,
+    promoDepth: 22
+  }
+];
+
+export const migrationMatrix = [
+  { from: 'Us', to: 'AlphaMobile', value: 0.12 },
+  { from: 'Us', to: 'BetaTel', value: 0.09 },
+  { from: 'Us', to: 'CableCoMobile', value: 0.06 },
+  { from: 'Us', to: 'MagentaNet', value: 0.08 },
+  { from: 'AlphaMobile', to: 'Us', value: 0.15 },
+  { from: 'BetaTel', to: 'Us', value: 0.11 },
+  { from: 'CableCoMobile', to: 'Us', value: 0.1 },
+  { from: 'MagentaNet', to: 'Us', value: 0.12 },
+  { from: 'AlphaMobile', to: 'MagentaNet', value: 0.07 },
+  { from: 'BetaTel', to: 'CableCoMobile', value: 0.05 },
+  { from: 'CableCoMobile', to: 'BetaTel', value: 0.04 },
+  { from: 'MagentaNet', to: 'AlphaMobile', value: 0.03 }
+];
+
+export type ChannelMix = Record<string, number>;
+
+export interface MicroSegment {
+  id: string;
+  parentSegmentId: string;
+  name: string;
+  size: number;
+  traits: string[];
+  priceSensitivity: number;
+  valueSensitivity: number;
+  defaultChannelMix: ChannelMix;
+  defaultOfferId: string;
+}
+
+export interface Recommendation {
+  channelMix: ChannelMix;
+  offerArchetypeId: string;
+  rationale: string[];
+  creativeTone: string[];
+  expected: {
+    paybackMonths: string;
+    grossMargin12Mo: number;
+    netAdds: number;
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-100 text-slate-900 antialiased;
+}
+
+.dark body {
+  @apply bg-slate-950 text-slate-100;
+}
+
+* {
+  @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-100;
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,24 @@
+export const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0
+});
+
+export const currencyFormatter2 = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 2
+});
+
+export const percentFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1
+});
+
+export const formatDelta = (value: number) => {
+  const formatted = value >= 0 ? `+${value.toFixed(1)}` : value.toFixed(1);
+  return `${formatted}%`;
+};
+
+export const formatPayback = (value: string) => (value === '>24' ? '> 24 mo' : `${value} mo`);

--- a/src/lib/intentParser.ts
+++ b/src/lib/intentParser.ts
@@ -1,0 +1,186 @@
+import { channels, offerArchetypes, type Channel, type MicroSegment, type OfferArchetype } from '../data/seeds';
+
+export interface ChannelShift {
+  from?: string;
+  to?: string;
+  delta: number;
+}
+
+export interface ChannelAdjust {
+  channelId: string;
+  delta: number;
+}
+
+export interface OfferAdjustments {
+  priceDelta?: number;
+  promoMonthsDelta?: number;
+  promoValueDelta?: number;
+  deviceSubsidyDelta?: number;
+}
+
+export interface AudienceChange {
+  include?: string[];
+  exclude?: string[];
+}
+
+export interface ParsedIntent {
+  channelShifts: ChannelShift[];
+  channelAdjusts: ChannelAdjust[];
+  offerAdjustments: OfferAdjustments;
+  audienceChange?: AudienceChange;
+  budgetDelta?: number;
+  paybackTarget?: number;
+  notes: string[];
+}
+
+const normaliseName = (value: string) => value.trim().toLowerCase();
+
+const channelByName = (label: string, channelData: Channel[]) => {
+  const normalised = normaliseName(label);
+  return channelData.find((channel) => normaliseName(channel.name) === normalised);
+};
+
+const offerByName = (label: string, offerData: OfferArchetype[]) => {
+  const normalised = normaliseName(label);
+  return offerData.find((offer) => normaliseName(offer.name) === normalised);
+};
+
+const microByName = (label: string, micros: MicroSegment[]) => {
+  const normalised = normaliseName(label);
+  return micros.find((micro) => normaliseName(micro.name) === normalised);
+};
+
+export const parseIntent = (input: string, context: { microSegments: MicroSegment[] }) => {
+  const text = input.toLowerCase();
+  const parsed: ParsedIntent = {
+    channelShifts: [],
+    channelAdjusts: [],
+    offerAdjustments: {},
+    notes: []
+  };
+
+  const percentPattern = /(-?\d+(?:\.\d+)?)%/g;
+  const moneyPattern = /\$(-?\d+(?:\.\d+)?)/g;
+
+  const shiftRegex = /shift\s+(\d+(?:\.\d+)?)%\s+budget\s+from\s+([a-zA-Z\s]+?)\s+to\s+([a-zA-Z\s]+?)(?:\.|$|,)/g;
+  let shiftMatch: RegExpExecArray | null;
+  while ((shiftMatch = shiftRegex.exec(text))) {
+    const [, pctRaw, fromLabel, toLabel] = shiftMatch;
+    const pct = parseFloat(pctRaw);
+    const fromChannel = channelByName(fromLabel, channels);
+    const toChannel = channelByName(toLabel, channels);
+    if (fromChannel && toChannel) {
+      parsed.channelShifts.push({ from: fromChannel.id, to: toChannel.id, delta: pct / 100 });
+      parsed.notes.push(`Shift ${pct}% from ${fromChannel.name} to ${toChannel.name}`);
+    }
+  }
+
+  const increaseRegex = /(increase|decrease)\s+([a-zA-Z\s]+?)\s+by\s+(\d+(?:\.\d+)?)%/g;
+  let incMatch: RegExpExecArray | null;
+  while ((incMatch = increaseRegex.exec(text))) {
+    const [, direction, label, pctRaw] = incMatch;
+    const channel = channelByName(label, channels);
+    if (channel) {
+      const sign = direction === 'increase' ? 1 : -1;
+      parsed.channelAdjusts.push({ channelId: channel.id, delta: (parseFloat(pctRaw) / 100) * sign });
+      parsed.notes.push(`${direction} ${channel.name} by ${pctRaw}%`);
+    }
+  }
+
+  const priceRegex = /(raise|increase|drop|decrease)\s+(?:price|monthly price)\s+(?:by\s+)?\$?(\d+(?:\.\d+)?)/;
+  const priceMatch = priceRegex.exec(text);
+  if (priceMatch) {
+    const [, direction, amount] = priceMatch;
+    const sign = direction === 'raise' || direction === 'increase' ? 1 : -1;
+    parsed.offerAdjustments.priceDelta = sign * parseFloat(amount);
+    parsed.notes.push(`${direction} price by $${amount}`);
+  }
+
+  const promoRegex = /(add|remove|extend|shorten)\s+(\d+)\s+promo\s+months/;
+  const promoMatch = promoRegex.exec(text);
+  if (promoMatch) {
+    const [, action, months] = promoMatch;
+    const sign = action === 'add' || action === 'extend' ? 1 : -1;
+    parsed.offerAdjustments.promoMonthsDelta = sign * parseInt(months, 10);
+    parsed.notes.push(`${action} ${months} promo months`);
+  }
+
+  const promoValueRegex = /(increase|decrease|drop|raise)\s+promo\s+value\s+by\s+\$?(\d+(?:\.\d+)?)/;
+  const promoValueMatch = promoValueRegex.exec(text);
+  if (promoValueMatch) {
+    const [, direction, amount] = promoValueMatch;
+    const sign = direction === 'increase' || direction === 'raise' ? 1 : -1;
+    parsed.offerAdjustments.promoValueDelta = sign * parseFloat(amount);
+    parsed.notes.push(`${direction} promo value by $${amount}`);
+  }
+
+  const deviceRegex = /(drop|reduce|increase|raise)\s+(?:device\s+subsidy|device\s+credit)\s+\$?(\d+(?:\.\d+)?)/;
+  const deviceMatch = deviceRegex.exec(text);
+  if (deviceMatch) {
+    const [, direction, amount] = deviceMatch;
+    const sign = direction === 'increase' || direction === 'raise' ? 1 : -1;
+    parsed.offerAdjustments.deviceSubsidyDelta = sign * parseFloat(amount);
+    parsed.notes.push(`${direction} device subsidy by $${amount}`);
+  }
+
+  const includeRegex = /(include|add)\s+([a-zA-Z\s]+?)(?:,|$|\.)/g;
+  let includeMatch: RegExpExecArray | null;
+  const includes: string[] = [];
+  while ((includeMatch = includeRegex.exec(text))) {
+    const [, , label] = includeMatch;
+    const micro = microByName(label, context.microSegments);
+    if (micro) {
+      includes.push(micro.id);
+    }
+  }
+
+  const excludeRegex = /(exclude|remove|drop)\s+([a-zA-Z\s]+?)(?:,|$|\.)/g;
+  let excludeMatch: RegExpExecArray | null;
+  const excludes: string[] = [];
+  while ((excludeMatch = excludeRegex.exec(text))) {
+    const [, , label] = excludeMatch;
+    const micro = microByName(label, context.microSegments);
+    if (micro) {
+      excludes.push(micro.id);
+    }
+  }
+
+  if (includes.length || excludes.length) {
+    parsed.audienceChange = {};
+    if (includes.length) {
+      parsed.audienceChange.include = includes;
+      parsed.notes.push(`Include: ${includes.length} micro-segment(s)`);
+    }
+    if (excludes.length) {
+      parsed.audienceChange.exclude = excludes;
+      parsed.notes.push(`Exclude: ${excludes.length} micro-segment(s)`);
+    }
+  }
+
+  const budgetRegex = /(increase|decrease|raise|lower|drop)\s+budget\s+by\s+\$?(\d+(?:\.\d+)?)/;
+  const budgetMatch = budgetRegex.exec(text);
+  if (budgetMatch) {
+    const [, direction, amount] = budgetMatch;
+    const sign = direction === 'increase' || direction === 'raise' ? 1 : -1;
+    parsed.budgetDelta = sign * parseFloat(amount);
+    parsed.notes.push(`${direction} budget by $${amount}`);
+  }
+
+  const paybackRegex = /payback\s*(?:<=|≤|under|below)\s*(\d+(?:\.\d+)?)/;
+  const paybackMatch = paybackRegex.exec(text.replace('months', '').replace('mos', ''));
+  if (paybackMatch) {
+    parsed.paybackTarget = parseFloat(paybackMatch[1]);
+    parsed.notes.push(`Target payback ≤ ${paybackMatch[1]} months`);
+  }
+
+  if (!parsed.notes.length) {
+    parsed.notes.push('No actionable instructions detected.');
+  }
+
+  return parsed;
+};
+
+export const describeIntent = (intent: ParsedIntent) => intent.notes.join('; ');
+
+export const defaultChannels = channels;
+export const defaultOffers = offerArchetypes;

--- a/src/lib/microSegments.ts
+++ b/src/lib/microSegments.ts
@@ -1,0 +1,107 @@
+import { channels, type MicroSegment, type Segment } from '../data/seeds';
+import { getOfferById, runCohort } from '../sim/tinySim';
+
+const personaLabels = [
+  'Value Seekers',
+  'Network Loyalists',
+  'Streaming Enthusiasts',
+  'Bundle Builders',
+  'Device Upgraders',
+  'Switch Sprinters',
+  'Coverage Conscious'
+];
+
+export const seededRandom = (seed: number) => {
+  let x = Math.sin(seed) * 10000;
+  return x - Math.floor(x);
+};
+
+export const nameByPersona = (segment: Segment, index: number) => {
+  const regionFocus = Object.entries(segment.regionMix).sort((a, b) => b[1] - a[1])[0]?.[0] ?? 'mixed';
+  const persona = personaLabels[(index + segment.name.length) % personaLabels.length];
+  return `${persona} (${regionFocus.charAt(0).toUpperCase()}${regionFocus.slice(1)})`;
+};
+
+export const buildTraits = (segment: Segment, variation: number) => {
+  const traits: string[] = [];
+  if (segment.priceSensitivity + variation > 0.75) traits.push('Price reactive');
+  if (segment.valueSensitivity + variation > 0.75) traits.push('Value maximisers');
+  if (segment.demographics.household === 'family') traits.push('Multi-line households');
+  if (segment.demographics.age === 'senior') traits.push('Needs assisted onboarding');
+  if (segment.demographics.age === 'youth') traits.push('Digital-first journeys');
+  if (!traits.length) traits.push('Balanced motivations');
+  return traits.slice(0, 3);
+};
+
+export const generateMicroSegments = (segment: Segment) => {
+  const clusters = 5;
+  const micros: MicroSegment[] = [];
+  const baseWeights = [0.18, 0.22, 0.2, 0.2, 0.2];
+  for (let i = 0; i < clusters; i += 1) {
+    const seed = segment.size * (i + 1);
+    const variation = seededRandom(seed) * 0.2 - 0.1;
+    const price = Math.min(0.95, Math.max(0.2, segment.priceSensitivity + variation));
+    const value = Math.min(0.95, Math.max(0.2, segment.valueSensitivity + variation * -1));
+    const size = Math.round(segment.size * baseWeights[i]);
+    const defaultOfferId = price > 0.7 ? 'offer-value-bundle' : segment.defaultOfferId;
+    const defaultChannelMix = Object.fromEntries(
+      Object.entries(segment.defaultChannelMix).map(([channelId, weight], idx) => {
+        const noise = seededRandom(seed + idx) * 0.1 - 0.05;
+        return [channelId, Math.max(0.05, weight + noise)];
+      })
+    );
+    micros.push({
+      id: `${segment.id}-micro-${i}`,
+      parentSegmentId: segment.id,
+      name: nameByPersona(segment, i),
+      size,
+      traits: buildTraits(segment, variation),
+      priceSensitivity: price,
+      valueSensitivity: value,
+      defaultChannelMix,
+      defaultOfferId
+    });
+  }
+  return micros;
+};
+
+export const normaliseMix = (mix: Record<string, number>) => {
+  const total = Object.values(mix).reduce((sum, value) => sum + value, 0);
+  return Object.fromEntries(Object.entries(mix).map(([key, value]) => [key, value / (total || 1)]));
+};
+
+export const buildRecommendation = (micro: MicroSegment) => {
+  const offer = getOfferById(micro.defaultOfferId);
+  const channelMix = normaliseMix(micro.defaultChannelMix);
+  const summary = runCohort({
+    segment: {
+      id: micro.id,
+      name: micro.name,
+      size: micro.size,
+      priceSensitivity: micro.priceSensitivity,
+      valueSensitivity: micro.valueSensitivity,
+      growthRate: 0.06
+    },
+    offer,
+    channelMix
+  });
+  const rationale = [
+    micro.priceSensitivity > 0.7 ? 'Lead with promo-led storytelling' : 'Reinforce network reliability',
+    micro.valueSensitivity > 0.75 ? 'Bundle emphasises perceived value' : 'Keep CAC disciplined with targeted channels'
+  ];
+  const creativeTone = micro.traits.includes('Digital-first journeys')
+    ? ['Energetic', 'Youthful social proof', 'Streaming hero moments']
+    : ['Pragmatic savings', 'Service reassurance', 'Family use-cases'];
+
+  return {
+    channelMix,
+    offerArchetypeId: offer.id,
+    rationale,
+    creativeTone,
+    expected: {
+      paybackMonths: summary.paybackMonths,
+      grossMargin12Mo: summary.grossMargin12Mo,
+      netAdds: summary.netAdds
+    }
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import './index.css';
+import { router } from './router';
+import { GlobalStoreProvider } from './store/globalStore';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <GlobalStoreProvider>
+      <RouterProvider router={router} />
+    </GlobalStoreProvider>
+  </React.StrictMode>
+);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,0 +1,18 @@
+import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { AppLayout } from './app/AppLayout';
+import { MarketRadarRoute } from './app/routes/MarketRadar';
+import { SegmentStudioRoute } from './app/routes/SegmentStudio';
+import { CampaignDesignerRoute } from './app/routes/CampaignDesigner';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <AppLayout />,
+    children: [
+      { index: true, element: <Navigate to="/market-radar" replace /> },
+      { path: '/market-radar', element: <MarketRadarRoute /> },
+      { path: '/segment-studio', element: <SegmentStudioRoute /> },
+      { path: '/campaign-designer', element: <CampaignDesignerRoute /> }
+    ]
+  }
+]);

--- a/src/sim/tinySim.ts
+++ b/src/sim/tinySim.ts
@@ -1,0 +1,179 @@
+import { assumptions as defaultAssumptions, channels, offerArchetypes, type Assumptions, type ChannelMix, type OfferArchetype, type Segment } from '../data/seeds';
+
+export interface CohortLike {
+  id: string;
+  name: string;
+  size: number;
+  priceSensitivity: number;
+  valueSensitivity: number;
+  growthRate?: number;
+}
+
+export interface CohortInput {
+  segment: CohortLike;
+  offer: OfferArchetype;
+  channelMix: ChannelMix;
+  assumptions?: Assumptions;
+  executionCostOverride?: number;
+}
+
+export interface CohortOutput {
+  takeRate: number;
+  reach: number;
+  netAdds: number;
+  arpu: number;
+  grossMarginPerMonth: number;
+  contributionPerMonth: number[];
+  cac: number;
+  cacPerSubscriber: number;
+  paybackMonths: string;
+  grossMargin12Mo: number;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const logistic = (x: number) => 1 / (1 + Math.exp(-x));
+
+const normaliseMix = (mix: ChannelMix): ChannelMix => {
+  const total = Object.values(mix).reduce((sum, weight) => sum + weight, 0);
+  if (!total || total === 0) {
+    return channels.reduce((acc, channel) => {
+      acc[channel.id] = 1 / channels.length;
+      return acc;
+    }, {} as ChannelMix);
+  }
+  const normalised: ChannelMix = {};
+  for (const [channelId, weight] of Object.entries(mix)) {
+    if (channels.some((c) => c.id === channelId)) {
+      normalised[channelId] = weight / total;
+    }
+  }
+  for (const channel of channels) {
+    if (!(channel.id in normalised)) {
+      normalised[channel.id] = 0;
+    }
+  }
+  return normalised;
+};
+
+export const getOfferById = (offerId: string) => offerArchetypes.find((offer) => offer.id === offerId)!;
+
+export const buildChannelMixFromOffer = (offer: OfferArchetype) => normaliseMix(offer.channelMixDefaults);
+
+export const takeRate = (segment: CohortLike, offer: OfferArchetype, channelMix: ChannelMix) => {
+  const mix = normaliseMix(channelMix);
+  const weightedEfficiency = Object.entries(mix).reduce((sum, [channelId, weight]) => {
+    const channel = channels.find((c) => c.id === channelId);
+    if (!channel) return sum;
+    return sum + weight * channel.convCurveParams.efficiency;
+  }, 0);
+
+  const reachPotential = Object.entries(mix).reduce((sum, [channelId, weight]) => {
+    const channel = channels.find((c) => c.id === channelId);
+    if (!channel) return sum;
+    return sum + weight * channel.convCurveParams.reach;
+  }, 0);
+
+  const baseline = 0.08 + (segment.growthRate ?? 0.05) * 0.6;
+  const offerValueBoost = (offer.promoValue / 20) * 0.25 + (offer.bundleFlag ? 0.25 : 0.12) + (offer.deviceSubsidy / 200) * 0.08;
+  const pricePressure = (offer.monthlyPrice / 100) * segment.priceSensitivity * 0.9;
+  const valueAffinity = segment.valueSensitivity * 0.6;
+  const efficiencyBoost = weightedEfficiency * 0.9;
+  const reachBoost = reachPotential * 0.7;
+
+  const logit = -1.6 + baseline + offerValueBoost + valueAffinity + efficiencyBoost + reachBoost - pricePressure;
+  return clamp(logistic(logit), 0.01, 0.48);
+};
+
+export const reachShare = (segment: CohortLike, channelMix: ChannelMix) => {
+  const mix = normaliseMix(channelMix);
+  const baseReach = Object.entries(mix).reduce((sum, [channelId, weight]) => {
+    const channel = channels.find((c) => c.id === channelId);
+    if (!channel) return sum;
+    return sum + weight * channel.convCurveParams.reach;
+  }, 0);
+  const modifier = 0.85 + segment.valueSensitivity * 0.15 - segment.priceSensitivity * 0.1;
+  return clamp(baseReach * modifier, 0.05, 0.65);
+};
+
+export const netAdds = (segment: CohortLike, tr: number, reach: number) => {
+  return Math.round(segment.size * reach * tr);
+};
+
+export const cac = (offer: OfferArchetype, channelMix: ChannelMix, assumptions: Assumptions, executionCostOverride?: number) => {
+  const mix = normaliseMix(channelMix);
+  const weightedCac = Object.entries(mix).reduce((sum, [channelId, weight]) => {
+    const channel = channels.find((c) => c.id === channelId);
+    if (!channel) return sum;
+    return sum + weight * channel.cac;
+  }, 0);
+  const promoCost = offer.promoMonths * offer.promoValue;
+  const deviceCost = offer.deviceSubsidy;
+  const executionCost = executionCostOverride ?? assumptions.executionCost;
+  return weightedCac + promoCost + deviceCost + executionCost;
+};
+
+export const arpu = (offer: OfferArchetype) => offer.monthlyPrice;
+
+export const monthlyContribution = (
+  offer: OfferArchetype,
+  assumptions: Assumptions
+) => {
+  const gm = arpu(offer) * assumptions.grossMarginRate;
+  const serviceCost = assumptions.servicingCostPerSubMo;
+  const amort = offer.deviceSubsidy / assumptions.deviceSubsidyAmortMo;
+  const contribution: number[] = [];
+  for (let month = 1; month <= 24; month += 1) {
+    const amortDeduction = month <= assumptions.deviceSubsidyAmortMo ? amort : 0;
+    contribution.push(gm - serviceCost - amortDeduction);
+  }
+  return { gm, contribution };
+};
+
+export const paybackMonths = (cacValue: number, contributions: number[]) => {
+  let cumulative = 0;
+  for (let month = 0; month < contributions.length; month += 1) {
+    cumulative += contributions[month];
+    if (cumulative >= cacValue) {
+      return (month + 1).toString();
+    }
+  }
+  return '>24';
+};
+
+export const grossMargin12Month = (contributions: number[]) => {
+  return contributions.slice(0, 12).reduce((sum, value) => sum + value, 0);
+};
+
+export const runCohort = (input: CohortInput): CohortOutput => {
+  const assumptions = input.assumptions ?? defaultAssumptions;
+  const tr = takeRate(input.segment, input.offer, input.channelMix);
+  const reach = reachShare(input.segment, input.channelMix);
+  const adds = netAdds(input.segment, tr, reach);
+  const cacPerSubscriber = cac(input.offer, input.channelMix, assumptions, input.executionCostOverride);
+  const totalCac = cacPerSubscriber * Math.max(adds, 1);
+  const { gm, contribution } = monthlyContribution(input.offer, assumptions);
+  const scaledContribution = contribution.map((value) => value * adds);
+  const gmTotal = gm * adds;
+  const payback = paybackMonths(totalCac, scaledContribution);
+  const margin12Mo = grossMargin12Month(scaledContribution);
+
+  return {
+    takeRate: tr,
+    reach,
+    netAdds: adds,
+    arpu: gm / assumptions.grossMarginRate,
+    grossMarginPerMonth: gmTotal,
+    contributionPerMonth: scaledContribution,
+    cac: totalCac,
+    cacPerSubscriber,
+    paybackMonths: payback,
+    grossMargin12Mo: margin12Mo
+  };
+};
+
+export const summariseCohort = (segment: Segment, offerId?: string, mix?: ChannelMix) => {
+  const offer = getOfferById(offerId ?? segment.defaultOfferId);
+  const channelMix = mix ?? segment.defaultChannelMix;
+  return runCohort({ segment, offer, channelMix });
+};

--- a/src/store/globalStore.tsx
+++ b/src/store/globalStore.tsx
@@ -1,0 +1,180 @@
+import React, { createContext, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import { createStore } from 'zustand/vanilla';
+import { useStore } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { assumptions as seedAssumptions, channels, offerArchetypes, segments, type Assumptions, type ChannelMix, type MicroSegment, type Recommendation, type Segment } from '../data/seeds';
+import { buildChannelMixFromOffer, getOfferById, summariseCohort } from '../sim/tinySim';
+
+export interface CampaignOfferConfig {
+  offerId: string;
+  price: number;
+  promoMonths: number;
+  promoValue: number;
+  deviceSubsidy: number;
+}
+
+export interface CampaignState {
+  audienceIds: string[];
+  offers: Record<string, CampaignOfferConfig>;
+  channelMix: Record<string, ChannelMix>;
+  budget: number;
+  schedule: { weeks: number; waves: number };
+  guardrails: { cacCeiling: number; paybackMax: number };
+}
+
+export interface InfoPanelState {
+  title: string;
+  description: string;
+  hint?: string;
+}
+
+export interface SelectionState {
+  activeSegmentId?: string;
+  selectedMicroSegmentIds: string[];
+  recommendationsByMicroSegment: Record<string, Recommendation>;
+  campaign: CampaignState;
+  assumptions: Assumptions;
+}
+
+export interface GlobalState extends SelectionState {
+  infoPanel: InfoPanelState;
+  setActiveSegmentId: (id: string) => void;
+  toggleMicroSegment: (id: string) => void;
+  setSelectedMicroSegments: (ids: string[]) => void;
+  setRecommendationsForMicro: (id: string, recommendation: Recommendation) => void;
+  setCampaign: (mutator: (campaign: CampaignState) => CampaignState) => void;
+  resetCampaign: (audienceIds: string[]) => void;
+  updateAssumptions: (assumptions: Partial<Assumptions>) => void;
+  setInfoPanel: (info: InfoPanelState) => void;
+  clearInfoPanel: () => void;
+}
+
+const createCampaignFromSegment = (segment: Segment): CampaignState => {
+  const offer = getOfferById(segment.defaultOfferId);
+  return {
+    audienceIds: [],
+    offers: {},
+    channelMix: {},
+    budget: Math.round(segment.size * 0.15),
+    schedule: { weeks: 12, waves: 2 },
+    guardrails: { cacCeiling: 350, paybackMax: 8 }
+  };
+};
+
+const initialCampaign = createCampaignFromSegment(segments[0]);
+
+const defaultState: SelectionState & { infoPanel: InfoPanelState } = {
+  activeSegmentId: segments[0].id,
+  selectedMicroSegmentIds: [],
+  recommendationsByMicroSegment: {},
+  campaign: initialCampaign,
+  assumptions: seedAssumptions,
+  infoPanel: {
+    title: 'Need-to-know',
+    description: 'Focus a widget to see curated context and assumptions.'
+  }
+};
+
+const StoreContext = createContext<ReturnType<typeof createStore<GlobalState>> | null>(null);
+
+const createGlobalState = () =>
+  createStore<GlobalState>()(
+    persist(
+      (set, get) => ({
+        ...defaultState,
+        setActiveSegmentId: (id) => {
+          set((state) => ({
+            activeSegmentId: id,
+            campaign: state.campaign.audienceIds.length ? state.campaign : createCampaignFromSegment(segments.find((s) => s.id === id) ?? segments[0])
+          }));
+        },
+        toggleMicroSegment: (id) => {
+          set((state) => {
+            const existing = new Set(state.selectedMicroSegmentIds);
+            if (existing.has(id)) {
+              existing.delete(id);
+            } else {
+              existing.add(id);
+            }
+            return { selectedMicroSegmentIds: Array.from(existing) };
+          });
+        },
+        setSelectedMicroSegments: (ids) => {
+          set(() => ({ selectedMicroSegmentIds: Array.from(new Set(ids)) }));
+        },
+        setRecommendationsForMicro: (id, recommendation) => {
+          set((state) => ({
+            recommendationsByMicroSegment: {
+              ...state.recommendationsByMicroSegment,
+              [id]: recommendation
+            }
+          }));
+        },
+        setCampaign: (mutator) => {
+          set((state) => ({ campaign: mutator(state.campaign) }));
+        },
+        resetCampaign: (audienceIds) => {
+          set((state) => {
+            const activeSegment = segments.find((seg) => seg.id === (state.activeSegmentId ?? segments[0].id)) ?? segments[0];
+            const base = createCampaignFromSegment(activeSegment);
+            base.audienceIds = audienceIds;
+            return { campaign: base };
+          });
+        },
+        updateAssumptions: (patch) => {
+          set((state) => ({ assumptions: { ...state.assumptions, ...patch } }));
+        },
+        setInfoPanel: (info) => set(() => ({ infoPanel: info })),
+        clearInfoPanel: () => set(() => ({ infoPanel: defaultState.infoPanel }))
+      }),
+      {
+        name: 'sbm-acquire-store',
+        storage: createJSONStorage(() => localStorage)
+      }
+    )
+  );
+
+export const GlobalStoreProvider = ({ children }: { children: ReactNode }) => {
+  const storeRef = useRef<ReturnType<typeof createGlobalState>>();
+  if (!storeRef.current) {
+    storeRef.current = createGlobalState();
+  }
+
+  const [hasHydrated, setHasHydrated] = useState(false);
+  useEffect(() => {
+    const unsub = storeRef.current!.persist.onFinishHydration(() => {
+      setHasHydrated(true);
+    });
+    if (storeRef.current!.getState().activeSegmentId) {
+      setHasHydrated(true);
+    }
+    return unsub;
+  }, []);
+
+  if (!hasHydrated) {
+    return null;
+  }
+
+  return <StoreContext.Provider value={storeRef.current}>{children}</StoreContext.Provider>;
+};
+
+export const useGlobalStore = <T,>(selector: (state: GlobalState) => T): T => {
+  const store = useContext(StoreContext);
+  if (!store) {
+    throw new Error('Global store not found');
+  }
+  return useStore(store, selector);
+};
+
+export const useActiveSegment = () => {
+  const activeSegmentId = useGlobalStore((state) => state.activeSegmentId);
+  return segments.find((segment) => segment.id === activeSegmentId) ?? segments[0];
+};
+
+export const useCampaignSummary = () => {
+  const { campaign, assumptions } = useGlobalStore((state) => ({ campaign: state.campaign, assumptions: state.assumptions }));
+  const activeSegment = useActiveSegment();
+  const offer = getOfferById(activeSegment.defaultOfferId);
+  const summary = summariseCohort(activeSegment, offer.id, buildChannelMixFromOffer(offer));
+  return { campaign, assumptions, summary };
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,18 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#1f7aec',
+          foreground: '#ffffff'
+        },
+        slate: {
+          950: '#0b1526'
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- set up the Vite + React + Tailwind scaffolding with global navigation, info rail, and persisted assumption controls via Zustand
- implement the Market Radar view with filters, KPI cards, segment carousel, comparison drawer, and the competitive intelligence block
- add Segment Studio micro-segmentation plus Campaign Designer autoplan, TinySim-driven economics, and a natural language command bar

## Testing
- pnpm install *(fails: registry 403)*

------
https://chatgpt.com/codex/tasks/task_b_68e55e22f324832eae615ea24183790a