### PR TITLE
feat: add subscriber acquisition prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# SBM
-Subscriber Management
+# Subscriber Base Management — Acquire Prototype
+
+This prototype showcases a three-step flow for identifying, refining, and activating subscriber cohorts across Market Radar, Segment Studio, and the Offering & Campaign Designer. It is a React + TypeScript + Vite application with Tailwind CSS styling, Zustand state management, and Recharts visualizations.
+
+## Getting Started
+
+```bash
+pnpm install
+pnpm dev
+```
+
+or use your preferred package manager (`npm install`, `yarn install`). The dev server runs on [http://localhost:5173](http://localhost:5173).
+
+## Key Features
+
+- **Market Radar** – Filter cohorts, visualize opportunity bubbles, drill into competitive maps, and curate a cart of promising cohorts.
+- **Segment Studio** – Break cohorts into micro-segments, evaluate attractiveness, and send selected audiences forward.
+- **Offering & Campaign Designer** – Adjust offers, channel mix, and budgets with live simulation via a deterministic tinySim engine.
+- **Persistence** – Cohort selections, filters, and campaign plans persist to `localStorage` so your workflow resumes on reload.
+
+Synthetic data lives in `src/data/seeds.ts`, and the simulation logic is implemented in `src/sim/tinySim.ts`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Subscriber Base Management</title>
+  </head>
+  <body class="bg-slate-900 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "sbm",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.390.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "recharts": "^2.8.0",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.3",
+    "vite": "^5.2.8"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,17 @@ import { NavLink, Route, Routes, useLocation, useNavigate } from 'react-router-d
 import MarketRadar from './app/routes/MarketRadar';
 import SegmentStudio from './app/routes/SegmentStudio';
 import CampaignDesigner from './app/routes/CampaignDesigner';
+import ExecutionHub from './tabs/ExecutionHub';
+import MonitoringDashboard from './tabs/MonitoringDashboard';
 import { useGlobalStore } from './store/global';
 import { useEffect } from 'react';
 
 const tabs = [
   { path: '/', label: 'Market Radar' },
   { path: '/segment-studio', label: 'Segment Studio' },
-  { path: '/campaign-designer', label: 'Offering & Campaign Designer' }
+  { path: '/campaign-designer', label: 'Offering & Campaign Designer' },
+  { path: '/execution-hub', label: 'Execution Hub' },
+  { path: '/monitoring', label: 'Monitoring Dashboard' }
 ];
 
 const App = () => {
@@ -66,6 +70,8 @@ const App = () => {
           <Route path="/" element={<MarketRadar />} />
           <Route path="/segment-studio" element={<SegmentStudio />} />
           <Route path="/campaign-designer" element={<CampaignDesigner />} />
+          <Route path="/execution-hub" element={<ExecutionHub />} />
+          <Route path="/monitoring" element={<MonitoringDashboard />} />
         </Routes>
       </main>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,75 @@
+import { NavLink, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import MarketRadar from './app/routes/MarketRadar';
+import SegmentStudio from './app/routes/SegmentStudio';
+import CampaignDesigner from './app/routes/CampaignDesigner';
+import { useGlobalStore } from './store/global';
+import { useEffect } from 'react';
+
+const tabs = [
+  { path: '/', label: 'Market Radar' },
+  { path: '/segment-studio', label: 'Segment Studio' },
+  { path: '/campaign-designer', label: 'Offering & Campaign Designer' }
+];
+
+const App = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const cartSegments = useGlobalStore((s) => s.cartSegmentIds);
+  const selectedMicroIds = useGlobalStore((s) => s.selectedMicroIds);
+  const initCampaign = useGlobalStore((s) => s.initCampaignFromSelection);
+
+  useEffect(() => {
+    if (location.pathname === '/segment-studio' && cartSegments.length === 0) {
+      navigate('/');
+    }
+  }, [cartSegments.length, location.pathname, navigate]);
+
+  useEffect(() => {
+    if (location.pathname === '/campaign-designer' && selectedMicroIds.length === 0) {
+      navigate('/segment-studio');
+    }
+  }, [selectedMicroIds.length, location.pathname, navigate]);
+
+  useEffect(() => {
+    if (location.pathname === '/campaign-designer') {
+      initCampaign();
+    }
+  }, [initCampaign, location.pathname]);
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-emerald-400">Subscriber Base Management</p>
+            <h1 className="text-2xl font-semibold text-white">Acquire</h1>
+          </div>
+          <nav className="flex gap-4">
+            {tabs.map((tab) => (
+              <NavLink
+                key={tab.path}
+                to={tab.path}
+                className={({ isActive }) =>
+                  `rounded-full px-4 py-2 text-sm font-medium transition ${
+                    isActive ? 'bg-emerald-500 text-slate-950 shadow-lg shadow-emerald-500/30' : 'bg-slate-900 text-slate-200 hover:bg-slate-800'
+                  }`
+                }
+              >
+                {tab.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto min-h-[calc(100vh-5rem)] max-w-7xl px-6 py-6">
+        <Routes>
+          <Route path="/" element={<MarketRadar />} />
+          <Route path="/segment-studio" element={<SegmentStudio />} />
+          <Route path="/campaign-designer" element={<CampaignDesigner />} />
+        </Routes>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/src/app/routes/CampaignDesigner.tsx
+++ b/src/app/routes/CampaignDesigner.tsx
@@ -1,0 +1,445 @@
+import React from 'react';
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import KpiTile from '../../components/KpiTile';
+import SelectionTray from '../../components/SelectionTray';
+import { simulateCampaign, AudienceSimInput } from '../../sim/tinySim';
+import { MicroSegment, useGlobalStore } from '../../store/global';
+
+const CampaignDesigner: React.FC = () => {
+  const assumptions = useGlobalStore((s) => s.assumptions);
+  const channels = useGlobalStore((s) => s.channels);
+  const offers = useGlobalStore((s) => s.offers);
+  const segments = useGlobalStore((s) => s.segments);
+  const microSegmentsByParent = useGlobalStore((s) => s.microSegmentsByParent);
+  const campaign = useGlobalStore((s) => s.campaign);
+  const updateCampaign = useGlobalStore((s) => s.updateCampaign);
+
+  const [savedScenarios, setSavedScenarios] = React.useState<
+    {
+      id: string;
+      label: string;
+      payback: number | string;
+      gm12: number;
+      conversion: number;
+      netAdds: number;
+    }[]
+  >([]);
+
+  const microMap = React.useMemo(() => {
+    const map = new Map<string, { parentId: string; data: MicroSegment }>();
+    Object.entries(microSegmentsByParent).forEach(([parentId, items]) => {
+      items.forEach((item) => {
+        map.set(item.id, { parentId, data: item });
+      });
+    });
+    return map;
+  }, [microSegmentsByParent]);
+
+  const audiences = React.useMemo(() => {
+    return campaign.audienceIds.map((audienceId) => {
+      const entry = microMap.get(audienceId);
+      if (!entry) return null;
+      const segment = segments.find((seg) => seg.id === entry.parentId);
+      if (!segment) return null;
+      const mix = campaign.channelMixByAudience[audienceId] ?? {};
+      return {
+        micro: entry.data,
+        segment,
+        offer: campaign.offerByAudience[audienceId] ?? offers[0],
+        channelMix: mix,
+        assumptions,
+        channels
+      };
+    }).filter(Boolean) as AudienceSimInput[];
+  }, [assumptions, campaign, channels, microMap, offers, segments]);
+
+  const simResults = React.useMemo(() => {
+    if (!audiences.length) {
+      return null;
+    }
+    return simulateCampaign({ audiences });
+  }, [audiences]);
+
+  const handleOfferChange = (audienceId: string, patch: Partial<typeof offers[number]>) => {
+    const next = { ...campaign.offerByAudience };
+    const base = next[audienceId] ?? offers[0];
+    next[audienceId] = { ...base, ...patch };
+    updateCampaign({ offerByAudience: next });
+  };
+
+  const handleChannelChange = (audienceId: string, channelId: string, value: number) => {
+    const baseMix =
+      campaign.channelMixByAudience[audienceId] ??
+      channels.reduce((acc, channel) => {
+        acc[channel.id] = 1 / Math.max(1, channels.length);
+        return acc;
+      }, {} as Record<string, number>);
+    const mix = { ...baseMix };
+    mix[channelId] = value;
+    const total = Object.values(mix).reduce((sum, weight) => sum + weight, 0) || 1;
+    const normalised = Object.fromEntries(Object.entries(mix).map(([id, weight]) => [id, weight / total]));
+    updateCampaign({ channelMixByAudience: { ...campaign.channelMixByAudience, [audienceId]: normalised } });
+  };
+
+  const saveScenario = () => {
+    if (!simResults) return;
+    const label = `Scenario ${savedScenarios.length + 1}`;
+    setSavedScenarios([
+      ...savedScenarios,
+      {
+        id: `${Date.now()}`,
+        label,
+        payback: simResults.blended.paybackMonths,
+        gm12: simResults.blended.gm12m,
+        conversion: simResults.blended.conversionRate,
+        netAdds: simResults.blended.netAdds
+      }
+    ]);
+  };
+
+  const winning = React.useMemo(() => {
+    if (!simResults) return null;
+    const options = [
+      {
+        id: 'current',
+        label: 'Current plan',
+        payback: simResults.blended.paybackMonths,
+        gm12: simResults.blended.gm12m,
+        conversion: simResults.blended.conversionRate,
+        netAdds: simResults.blended.netAdds
+      },
+      ...savedScenarios
+    ];
+    return options.reduce((best, scenario) => {
+      const bestPayback = typeof best.payback === 'number' ? best.payback : 25;
+      const scenarioPayback = typeof scenario.payback === 'number' ? scenario.payback : 25;
+      return scenarioPayback < bestPayback ? scenario : best;
+    });
+  }, [savedScenarios, simResults]);
+
+  return (
+    <div className="grid grid-cols-[280px_1fr_300px] gap-6">
+      <aside className="flex flex-col gap-4">
+        <div className="card border border-slate-800 p-4">
+          <p className="text-xs uppercase tracking-wide text-emerald-400">How to use</p>
+          <p className="mt-2 text-sm text-slate-300">
+            Design and simulate offers, bundles, and channel mixes for your selected sub-segments. Adjust inputs to see conversion, CAC payback, and margin update in real time.
+          </p>
+        </div>
+        <div className="card border border-slate-800 p-4">
+          <h3 className="text-sm font-semibold text-white">Audiences</h3>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {campaign.audienceIds.map((id) => {
+              const entry = microMap.get(id);
+              const segment = entry ? segments.find((seg) => seg.id === entry.parentId) : undefined;
+              return (
+                <span key={id} className="info-chip">
+                  {segment?.name} • {entry?.data.name}
+                </span>
+              );
+            })}
+          </div>
+          <p className="mt-3 text-[11px] uppercase tracking-wide text-emerald-400">Primary data sources (est.): Synth Cohort Econ / Campaign Designer Logs</p>
+        </div>
+        <div className="card border border-slate-800 p-4">
+          <h3 className="text-sm font-semibold text-white">Budget & guardrails</h3>
+          <div className="space-y-3 text-sm text-slate-300">
+            <div>
+              <label className="text-xs uppercase tracking-wide text-slate-400">Total budget</label>
+              <input
+                type="number"
+                value={campaign.budgetTotal}
+                onChange={(event) => updateCampaign({ budgetTotal: Number(event.target.value) })}
+                className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label className="text-xs uppercase tracking-wide text-slate-400">CAC ceiling</label>
+                <input
+                  type="number"
+                  value={campaign.guardrails.cacCeiling ?? ''}
+                  onChange={(event) => updateCampaign({ guardrails: { ...campaign.guardrails, cacCeiling: Number(event.target.value) } })}
+                  className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="text-xs uppercase tracking-wide text-slate-400">Payback target</label>
+                <input
+                  type="number"
+                  value={campaign.guardrails.paybackTarget ?? ''}
+                  onChange={(event) => updateCampaign({ guardrails: { ...campaign.guardrails, paybackTarget: Number(event.target.value) } })}
+                  className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
+                />
+              </div>
+            </div>
+          </div>
+          <details className="mt-3 space-y-2 text-sm text-slate-300">
+            <summary className="cursor-pointer text-xs uppercase tracking-wide text-emerald-400">Advanced assumptions</summary>
+            <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-400">
+              Margin %
+              <input
+                type="number"
+                step={0.01}
+                value={assumptions.grossMarginRate}
+                onChange={(event) => updateCampaign({})}
+                disabled
+                className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white"
+              />
+            </label>
+            <p className="text-xs text-slate-500">Assumptions fixed for prototype; adjust in tinySim for deeper what-ifs.</p>
+          </details>
+        </div>
+      </aside>
+      <section className="flex flex-col gap-6">
+        {simResults ? (
+          <div className="grid grid-cols-5 gap-3">
+            <KpiTile
+              label="CAC Payback (mo)"
+              value={typeof simResults.blended.paybackMonths === 'number' ? simResults.blended.paybackMonths : simResults.blended.paybackMonths}
+              info={{
+                title: 'CAC Payback (months)',
+                description: 'Months until fully-loaded CAC is covered by cumulative contribution.',
+                primarySource: 'Synth Cohort Econ'
+              }}
+            />
+            <KpiTile
+              label="12-mo Incremental GM"
+              value={`$${simResults.blended.gm12m.toLocaleString()}`}
+              info={{
+                title: '12-Month Incremental Gross Margin',
+                description: 'Gross margin over first 12 months after servicing costs and device amortization.',
+                primarySource: 'Synth Cohort Econ'
+              }}
+            />
+            <KpiTile label="Conversion %" value={`${(simResults.blended.conversionRate * 100).toFixed(1)}%`} />
+            <KpiTile label="Net adds" value={simResults.blended.netAdds.toLocaleString()} />
+            <KpiTile label="Margin %" value={`${simResults.blended.marginPct}%`} />
+          </div>
+        ) : (
+          <div className="card border border-slate-800 p-6 text-center text-sm text-slate-300">Add sub-segments to simulate.</div>
+        )}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="card flex flex-col gap-4 border border-slate-800 p-4">
+            <h3 className="text-lg font-semibold text-white">Performance dashboard</h3>
+            {simResults ? (
+              <div className="h-48">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={simResults.blended.timeline}>
+                    <XAxis dataKey="month" stroke="#64748b" tick={{ fill: '#94a3b8', fontSize: 12 }} />
+                    <YAxis stroke="#64748b" tick={{ fill: '#94a3b8', fontSize: 12 }} />
+                    <Tooltip
+                      content={({ active, payload }) => {
+                        if (!active || !payload?.length) return null;
+                        return (
+                          <div className="card border border-emerald-500/20 p-2 text-xs">
+                            Month {payload[0].payload.month}: {payload[0].payload.cumulativeContribution} per sub
+                          </div>
+                        );
+                      }}
+                    />
+                    <Line type="monotone" dataKey="cumulativeContribution" stroke="#10b981" strokeWidth={2} dot={false} />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            ) : (
+              <p className="text-sm text-slate-400">Run a simulation to see the payback curve.</p>
+            )}
+            {simResults ? (
+              <div className="grid grid-cols-2 gap-3 text-sm text-slate-300">
+                <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+                  <p className="text-xs uppercase tracking-wide text-slate-500">CAC</p>
+                  <p className="text-lg font-semibold text-white">${simResults.blended.breakdown.cac.toLocaleString()}</p>
+                </div>
+                <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Promo cost</p>
+                  <p className="text-lg font-semibold text-white">${simResults.blended.breakdown.promoCost.toLocaleString()}</p>
+                </div>
+                <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Device subsidy</p>
+                  <p className="text-lg font-semibold text-white">${simResults.blended.breakdown.deviceSubsidy.toLocaleString()}</p>
+                </div>
+                <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Execution cost</p>
+                  <p className="text-lg font-semibold text-white">${simResults.blended.breakdown.executionCost.toLocaleString()}</p>
+                </div>
+              </div>
+            ) : null}
+          </div>
+          <div className="card flex flex-col gap-4 border border-slate-800 p-4">
+            <h3 className="text-lg font-semibold text-white">Offer & channel designer</h3>
+            {campaign.audienceIds.map((audienceId) => {
+              const entry = microMap.get(audienceId);
+              const segment = entry ? segments.find((seg) => seg.id === entry.parentId) : undefined;
+              const currentOffer = campaign.offerByAudience[audienceId] ?? offers[0];
+              const mix = campaign.channelMixByAudience[audienceId] ?? {};
+              return (
+                <div key={audienceId} className="rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-200">
+                  <h4 className="text-base font-semibold text-white">{segment?.name} — {entry?.data.name}</h4>
+                  <div className="mt-3 grid grid-cols-2 gap-3">
+                    <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-400">
+                      Monthly price (${currentOffer.monthlyPrice})
+                      <input
+                        type="range"
+                        min={40}
+                        max={90}
+                        value={currentOffer.monthlyPrice}
+                        onChange={(event) => handleOfferChange(audienceId, { monthlyPrice: Number(event.target.value) })}
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-400">
+                      Promo months ({currentOffer.promoMonths})
+                      <input
+                        type="range"
+                        min={0}
+                        max={12}
+                        value={currentOffer.promoMonths}
+                        onChange={(event) => handleOfferChange(audienceId, { promoMonths: Number(event.target.value) })}
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-400">
+                      Promo value (${currentOffer.promoValue})
+                      <input
+                        type="range"
+                        min={0}
+                        max={40}
+                        value={currentOffer.promoValue}
+                        onChange={(event) => handleOfferChange(audienceId, { promoValue: Number(event.target.value) })}
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-400">
+                      Device subsidy (${currentOffer.deviceSubsidy})
+                      <input
+                        type="range"
+                        min={0}
+                        max={400}
+                        step={20}
+                        value={currentOffer.deviceSubsidy}
+                        onChange={(event) => handleOfferChange(audienceId, { deviceSubsidy: Number(event.target.value) })}
+                      />
+                    </label>
+                  </div>
+                  <div className="mt-4 space-y-2">
+                    <p className="text-xs uppercase tracking-wide text-slate-400">Channel allocation</p>
+                    {channels.map((channel) => (
+                      <div key={channel.id} className="flex items-center gap-3 text-xs text-slate-300">
+                        <span className="w-24 text-slate-400">{channel.name}</span>
+                        <input
+                          type="range"
+                          min={0}
+                          max={1}
+                          step={0.05}
+                          value={mix[channel.id] ?? 0}
+                          onChange={(event) => handleChannelChange(audienceId, channel.id, Number(event.target.value))}
+                        />
+                        <span className="w-10 text-right">{Math.round((mix[channel.id] ?? 0) * 100)}%</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        <div className="card flex flex-col gap-4 border border-slate-800 p-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-white">Scenario comparison</h3>
+            <button
+              onClick={saveScenario}
+              className="rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-600"
+            >
+              Save Scenario
+            </button>
+          </div>
+          <div className="grid grid-cols-4 gap-2 text-sm">
+            <span className="text-xs uppercase tracking-wide text-slate-400">Scenario</span>
+            <span className="text-xs uppercase tracking-wide text-slate-400">Payback</span>
+            <span className="text-xs uppercase tracking-wide text-slate-400">12-mo GM</span>
+            <span className="text-xs uppercase tracking-wide text-slate-400">Net adds</span>
+            {savedScenarios.map((scenario) => (
+              <React.Fragment key={scenario.id}>
+                <span className="font-semibold text-white">{scenario.label}</span>
+                <span>{typeof scenario.payback === 'number' ? `${scenario.payback} mo` : scenario.payback}</span>
+                <span>${scenario.gm12.toLocaleString()}</span>
+                <span>{scenario.netAdds.toLocaleString()}</span>
+              </React.Fragment>
+            ))}
+          </div>
+        </div>
+        {winning ? (
+          <div className="card flex items-center justify-between border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">
+            <div>
+              <p className="text-xs uppercase tracking-wide">Winning play</p>
+              <p className="text-lg font-semibold text-white">{winning.label}</p>
+              <p>
+                {typeof winning.payback === 'number' ? `${winning.payback} mo` : winning.payback} payback • ${winning.gm12.toLocaleString()} GM • {(winning.conversion * 100).toFixed(1)}% conversion
+              </p>
+            </div>
+            <button className="rounded-full border border-emerald-500 bg-slate-900 px-4 py-2 text-sm font-semibold text-emerald-200 hover:bg-emerald-500/20">
+              Set as Recommended Plan
+            </button>
+          </div>
+        ) : null}
+      </section>
+      <aside className="card flex h-full flex-col gap-4 border border-slate-800 p-4">
+        <header>
+          <p className="text-xs uppercase tracking-wide text-emerald-400">AI narrative & insights</p>
+          <h3 className="text-lg font-semibold text-white">Here’s how to optimize your campaign.</h3>
+        </header>
+        {simResults ? (
+          <ul className="space-y-2 text-sm text-slate-300">
+            <li>Increase Search +5% to approach ≤ {typeof simResults.blended.paybackMonths === 'number' ? simResults.blended.paybackMonths - 1 : 8} mo payback.</li>
+            <li>Lower promo depth by $5 to lift margin {Math.round(simResults.blended.marginPct * 0.1)} bps.</li>
+            <li>Shift 3% from Retail to Email to boost reach efficiently.</li>
+          </ul>
+        ) : (
+          <p className="text-sm text-slate-400">Run a simulation to unlock insights.</p>
+        )}
+        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-3 text-xs text-emerald-200">
+          Confidence: {simResults ? 'High — rich digital signals' : 'Awaiting simulation'}
+        </div>
+        <details className="text-xs text-slate-400">
+          <summary className="cursor-pointer text-emerald-300">Supporting data</summary>
+          <p className="mt-2">Primary data sources (est.): Synth Cohort Econ / Channel Benchmarks / Offer Lab</p>
+        </details>
+      </aside>
+      <div className="col-span-3">
+        <SelectionTray
+          title="Campaign summary"
+          items={campaign.audienceIds.map((id) => {
+            const entry = microMap.get(id);
+            const segment = entry ? segments.find((seg) => seg.id === entry.parentId) : undefined;
+            return {
+              id,
+              label: segment ? `${segment.name} — ${entry?.data.name}` : id,
+              subtitle: entry ? `${(entry.data.sizeShare * 100).toFixed(1)}% of cohort` : ''
+            };
+          })}
+          metrics={simResults ? [
+            { label: 'Payback', value: typeof simResults.blended.paybackMonths === 'number' ? `${simResults.blended.paybackMonths} mo` : simResults.blended.paybackMonths },
+            { label: '12-mo GM', value: `$${simResults.blended.gm12m.toLocaleString()}` },
+            { label: 'Net adds', value: simResults.blended.netAdds.toLocaleString() }
+          ] : [
+            { label: 'Payback', value: '–' },
+            { label: '12-mo GM', value: '–' },
+            { label: 'Net adds', value: '–' }
+          ]}
+          ctaLabel="Export JSON"
+          onCta={() => {
+            const payload = JSON.stringify({ campaign, results: simResults }, null, 2);
+            const blob = new Blob([payload], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = 'campaign-plan.json';
+            link.click();
+            URL.revokeObjectURL(url);
+          }}
+          disabled={!simResults}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default CampaignDesigner;

--- a/src/app/routes/CampaignDesigner.tsx
+++ b/src/app/routes/CampaignDesigner.tsx
@@ -274,7 +274,7 @@ const CampaignDesigner: React.FC = () => {
           </details>
         </div>
       </aside>
-      <section className="flex flex-col gap-6">
+      <section className="flex min-w-0 flex-col gap-6">
         <div className="card border border-slate-800 p-5">
           <div className="flex items-start justify-between gap-4">
             <div>
@@ -291,16 +291,25 @@ const CampaignDesigner: React.FC = () => {
                 Digital-first bundles for priority micro-segments with tight promo discipline and high-margin channel mix.
               </p>
               <div className="mt-6 flex flex-wrap gap-4 text-sm">
-                <div>
-                  <p className="text-xs uppercase text-emerald-200">Payback</p>
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2 text-xs uppercase text-emerald-200">
+                    <span>Payback</span>
+                    <InfoPopover title="Payback highlight" description="Shows the timeline to recover acquisition costs for the leading scenario." />
+                  </div>
                   <p className="text-lg font-semibold">{simResults ? (typeof simResults.blended.paybackMonths === 'number' ? `${simResults.blended.paybackMonths} mo` : simResults.blended.paybackMonths) : '–'}</p>
                 </div>
-                <div>
-                  <p className="text-xs uppercase text-emerald-200">12-mo GM</p>
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2 text-xs uppercase text-emerald-200">
+                    <span>12-mo GM</span>
+                    <InfoPopover title="Gross margin highlight" description="Captures first-year gross margin after servicing and subsidies." />
+                  </div>
                   <p className="text-lg font-semibold">{simResults ? `$${simResults.blended.gm12m.toLocaleString()}` : '–'}</p>
                 </div>
-                <div>
-                  <p className="text-xs uppercase text-emerald-200">Conversion</p>
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2 text-xs uppercase text-emerald-200">
+                    <span>Conversion</span>
+                    <InfoPopover title="Conversion highlight" description="Percent of targeted audience expected to activate." />
+                  </div>
                   <p className="text-lg font-semibold">{simResults ? `${(simResults.blended.conversionRate * 100).toFixed(1)}%` : '–'}</p>
                 </div>
               </div>
@@ -441,7 +450,10 @@ const CampaignDesigner: React.FC = () => {
                   </div>
                   <div className="mt-3 grid grid-cols-2 gap-3">
                     <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-400">
-                      Monthly price (${currentOffer.monthlyPrice})
+                      <span className="flex items-center justify-between">
+                        <span>Monthly price (${currentOffer.monthlyPrice})</span>
+                        <InfoPopover title="Monthly price" description="Drag to set the customer-facing price point." placement="left" />
+                      </span>
                       <input
                         type="range"
                         min={40}
@@ -451,7 +463,10 @@ const CampaignDesigner: React.FC = () => {
                       />
                     </label>
                     <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-400">
-                      Promo months ({currentOffer.promoMonths})
+                      <span className="flex items-center justify-between">
+                        <span>Promo months ({currentOffer.promoMonths})</span>
+                        <InfoPopover title="Promo months" description="Number of months the promotional rate applies." placement="left" />
+                      </span>
                       <input
                         type="range"
                         min={0}
@@ -461,7 +476,10 @@ const CampaignDesigner: React.FC = () => {
                       />
                     </label>
                     <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-400">
-                      Promo value (${currentOffer.promoValue})
+                      <span className="flex items-center justify-between">
+                        <span>Promo value (${currentOffer.promoValue})</span>
+                        <InfoPopover title="Promo value" description="Adjust incentive depth applied during the promo window." placement="left" />
+                      </span>
                       <input
                         type="range"
                         min={0}
@@ -471,7 +489,10 @@ const CampaignDesigner: React.FC = () => {
                       />
                     </label>
                     <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-400">
-                      Device subsidy (${currentOffer.deviceSubsidy})
+                      <span className="flex items-center justify-between">
+                        <span>Device subsidy (${currentOffer.deviceSubsidy})</span>
+                        <InfoPopover title="Device subsidy" description="Controls the equipment incentive amortized in the sim." placement="left" />
+                      </span>
                       <input
                         type="range"
                         min={0}

--- a/src/app/routes/CampaignDesigner.tsx
+++ b/src/app/routes/CampaignDesigner.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import InfoPopover from '../../components/InfoPopover';
 import KpiTile from '../../components/KpiTile';
 import SelectionTray from '../../components/SelectionTray';
+import Info from '../../components/Info';
+import { useToast } from '../../components/ToastProvider';
 import { simulateCampaign, AudienceSimInput } from '../../sim/tinySim';
 import { MicroSegment, useGlobalStore } from '../../store/global';
+import { ChannelKey, useAppStore } from '../../store/AppStore';
+
+const channelKeyList: ChannelKey[] = ['Search', 'Social', 'Email', 'Retail', 'Field'];
+const channelIdToKey: Record<string, ChannelKey> = {
+  'ch-search': 'Search',
+  'ch-social': 'Social',
+  'ch-email': 'Email',
+  'ch-retail': 'Retail',
+  'ch-field': 'Field'
+};
 
 const CampaignDesigner: React.FC = () => {
   const assumptions = useGlobalStore((s) => s.assumptions);
@@ -14,6 +27,11 @@ const CampaignDesigner: React.FC = () => {
   const microSegmentsByParent = useGlobalStore((s) => s.microSegmentsByParent);
   const campaign = useGlobalStore((s) => s.campaign);
   const updateCampaign = useGlobalStore((s) => s.updateCampaign);
+  const navigate = useNavigate();
+  const { campaigns: liveCampaigns, launchCampaign, scoreImpact } = useAppStore();
+  const { pushToast } = useToast();
+
+  const [launchOpen, setLaunchOpen] = React.useState(false);
 
   const [savedScenarios, setSavedScenarios] = React.useState<
     {
@@ -118,6 +136,87 @@ const CampaignDesigner: React.FC = () => {
     });
   }, [savedScenarios, simResults]);
 
+  const aggregatedCohorts = React.useMemo(() => {
+    return campaign.audienceIds
+      .map((id) => {
+        const entry = microMap.get(id);
+        if (!entry) return null;
+        const segment = segments.find((seg) => seg.id === entry.parentId);
+        if (!segment) return null;
+        return {
+          id,
+          name: `${segment.name} — ${entry.data.name}`,
+          size: Math.round(segment.size * entry.data.sizeShare)
+        };
+      })
+      .filter(Boolean) as { id: string; name: string; size: number }[];
+  }, [campaign.audienceIds, microMap, segments]);
+
+  const aggregatedChannels = React.useMemo(() => {
+    const totals: Record<ChannelKey, number> = {
+      Search: 0,
+      Social: 0,
+      Email: 0,
+      Retail: 0,
+      Field: 0
+    };
+    let weightSum = 0;
+    campaign.audienceIds.forEach((id) => {
+      const entry = microMap.get(id);
+      if (!entry) return;
+      const mix = campaign.channelMixByAudience[id] ?? {};
+      const weight = entry.data.sizeShare;
+      weightSum += weight;
+      Object.entries(mix).forEach(([channelId, value]) => {
+        const key = channelIdToKey[channelId];
+        if (!key) return;
+        totals[key] += value * weight;
+      });
+    });
+    if (weightSum === 0) return totals;
+    return channelKeyList.reduce((acc, key) => {
+      acc[key] = Number((totals[key] / weightSum).toFixed(3));
+      return acc;
+    }, {} as Record<ChannelKey, number>);
+  }, [campaign.audienceIds, campaign.channelMixByAudience, microMap]);
+
+  const aggregatedOffer = React.useMemo(() => {
+    let totalWeight = 0;
+    let price = 0;
+    let promoMonths = 0;
+    let promoValue = 0;
+    let deviceSubsidy = 0;
+    campaign.audienceIds.forEach((id) => {
+      const entry = microMap.get(id);
+      if (!entry) return;
+      const offer = campaign.offerByAudience[id] ?? offers[0];
+      const weight = entry.data.sizeShare;
+      totalWeight += weight;
+      price += offer.monthlyPrice * weight;
+      promoMonths += offer.promoMonths * weight;
+      promoValue += offer.promoValue * weight;
+      deviceSubsidy += offer.deviceSubsidy * weight;
+    });
+    if (totalWeight === 0) {
+      const fallback = offers[0];
+      return {
+        price: fallback.monthlyPrice,
+        promoMonths: fallback.promoMonths,
+        promoValue: fallback.promoValue,
+        deviceSubsidy: fallback.deviceSubsidy
+      };
+    }
+    return {
+      price: Number((price / totalWeight).toFixed(2)),
+      promoMonths: Math.round(promoMonths / totalWeight),
+      promoValue: Math.round(promoValue / totalWeight),
+      deviceSubsidy: Math.round(deviceSubsidy / totalWeight)
+    };
+  }, [campaign.audienceIds, campaign.offerByAudience, microMap, offers]);
+
+  const launchReady = Boolean(simResults && campaign.audienceIds.length);
+  const viewMonitoringDisabled = liveCampaigns.length === 0;
+
   const exportSummary = React.useCallback(() => {
     if (!simResults) return;
     const audienceLines = campaign.audienceIds
@@ -151,6 +250,57 @@ const CampaignDesigner: React.FC = () => {
     URL.revokeObjectURL(url);
   }, [campaign.audienceIds, campaign.budgetTotal, microMap, segments, simResults, winning]);
 
+  const confirmLaunch = React.useCallback(() => {
+    if (!simResults || !aggregatedCohorts.length) return;
+    const heuristics = scoreImpact(aggregatedChannels, {
+      price: aggregatedOffer.price,
+      promoMonths: aggregatedOffer.promoMonths,
+      promoValue: aggregatedOffer.promoValue,
+      deviceSubsidy: aggregatedOffer.deviceSubsidy
+    });
+    const paybackValue =
+      typeof simResults.blended.paybackMonths === 'number'
+        ? simResults.blended.paybackMonths
+        : heuristics.paybackMo;
+    const launched = launchCampaign({
+      name: `${winning ? winning.label : 'Studio Activation'} Launch`,
+      cohorts: aggregatedCohorts.map((cohort) => ({
+        id: cohort.id,
+        name: cohort.name,
+        size: cohort.size
+      })),
+      channels: aggregatedChannels,
+      offer: {
+        price: aggregatedOffer.price,
+        promoMonths: aggregatedOffer.promoMonths,
+        promoValue: aggregatedOffer.promoValue,
+        deviceSubsidy: aggregatedOffer.deviceSubsidy
+      },
+      agent: 'Acquisition',
+      kpis: {
+        cvr: Number((simResults.blended.conversionRate * 100).toFixed(2)),
+        arpuDelta: heuristics.arpuDelta,
+        gm12: simResults.blended.gm12m,
+        netAdds: simResults.blended.netAdds,
+        paybackMo: Number(paybackValue.toFixed(2)),
+        npsDelta: heuristics.npsDelta
+      }
+    });
+    setLaunchOpen(false);
+    pushToast({ description: 'Campaign launched to Execution Hub.', variant: 'success' });
+    navigate('/execution-hub', { state: { selectedCampaignId: launched.id, fromLaunch: true } });
+  }, [
+    aggregatedChannels,
+    aggregatedCohorts,
+    aggregatedOffer,
+    launchCampaign,
+    navigate,
+    pushToast,
+    scoreImpact,
+    simResults,
+    winning
+  ]);
+
   return (
     <div className="space-y-6">
       <div className="card border border-emerald-500/20 bg-slate-900/70 p-5">
@@ -161,10 +311,43 @@ const CampaignDesigner: React.FC = () => {
               Design offers, channel mixes, and budgets for selected micro-segments, then simulate impact before exporting a leadership-ready summary.
             </p>
           </div>
-          <InfoPopover
-            title="Campaign Designer overview"
-            description="Fine-tune pricing, promos, and channels while tinySim updates payback, margin, and net adds in real time."
-          />
+          <div className="flex flex-col items-end gap-3">
+            <Info
+              title="Campaign Designer overview"
+              body={(
+                <>
+                  <p><strong>How it is used:</strong> Tune pricing, promotions, and channel mix until guardrails are met.</p>
+                  <p><strong>What it means:</strong> tinySim powers the live KPIs using synthetic economics and telemetry.</p>
+                </>
+              )}
+            />
+            <div className="flex flex-wrap justify-end gap-2">
+              <button
+                type="button"
+                className={`rounded-full border px-4 py-2 text-sm font-semibold transition ${
+                  launchReady
+                    ? 'border-emerald-500/60 bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30'
+                    : 'border-slate-700 bg-slate-900/60 text-slate-500'
+                }`}
+                onClick={() => setLaunchOpen(true)}
+                disabled={!launchReady}
+              >
+                Launch to Execution Hub
+              </button>
+              <button
+                type="button"
+                className={`rounded-full border px-4 py-2 text-sm font-semibold transition ${
+                  viewMonitoringDisabled
+                    ? 'border-slate-700 bg-slate-900/60 text-slate-500'
+                    : 'border-slate-700 text-slate-200 hover:border-emerald-400/60 hover:text-emerald-200'
+                }`}
+                onClick={() => navigate('/monitoring')}
+                disabled={viewMonitoringDisabled}
+              >
+                View Monitoring
+              </button>
+            </div>
+          </div>
         </div>
         <div className="mt-4 grid gap-3 text-sm text-slate-200 md:grid-cols-3">
           <div className="flex items-start gap-2">
@@ -212,7 +395,15 @@ const CampaignDesigner: React.FC = () => {
         <div className="card border border-slate-800 p-4">
           <div className="flex items-center justify-between">
             <h3 className="text-sm font-semibold text-white">Budget & guardrails</h3>
-            <InfoPopover title="Budget & guardrails" description="Set the constraints that guide the simulation." />
+            <Info
+              title="Budget & guardrails"
+              body={(
+                <>
+                  <p><strong>How it is used:</strong> Anchor the simulation to the spend envelope and CAC guardrails leadership approved.</p>
+                  <p><strong>What it means:</strong> Synthetic values mirror CRM finance baselines for this demo environment.</p>
+                </>
+              )}
+            />
           </div>
           <div className="mt-3 space-y-3 text-sm text-slate-300">
             <div>
@@ -374,7 +565,15 @@ const CampaignDesigner: React.FC = () => {
           <div className="card flex flex-col gap-4 border border-slate-800 p-4">
             <div className="flex items-center justify-between">
               <h3 className="text-lg font-semibold text-white">Performance dashboard</h3>
-              <InfoPopover title="Performance dashboard" description="Track contribution build and cost breakdowns." />
+              <Info
+                title="Performance dashboard"
+                body={(
+                  <>
+                    <p><strong>How it is used:</strong> Read the payback curve and cost breakdowns to validate if the play meets finance expectations.</p>
+                    <p><strong>What it means:</strong> Sparkline reflects synthetic contribution by month using the same logic as Execution Hub.</p>
+                  </>
+                )}
+              />
             </div>
             {simResults ? (
               <div className="h-48">
@@ -435,7 +634,15 @@ const CampaignDesigner: React.FC = () => {
           <div className="card flex flex-col gap-4 border border-slate-800 p-4">
             <div className="flex items-center justify-between">
               <h3 className="text-lg font-semibold text-white">Offer & channel designer</h3>
-              <InfoPopover title="Designer" description="Adjust levers for each audience to see immediate impact." />
+              <Info
+                title="Offer & channel designer"
+                body={(
+                  <>
+                    <p><strong>How it is used:</strong> Slide pricing, promo depth, and channel allocation to re-balance the play per micro-segment.</p>
+                    <p><strong>What it means:</strong> Sliders feed tinySim’s synthetic take-rate and CAC models instantly.</p>
+                  </>
+                )}
+              />
             </div>
             {campaign.audienceIds.map((audienceId) => {
               const entry = microMap.get(audienceId);
@@ -580,7 +787,15 @@ const CampaignDesigner: React.FC = () => {
             <p className="text-xs uppercase tracking-wide text-emerald-400">AI narrative & insights</p>
             <h3 className="text-lg font-semibold text-white">Here’s how to optimize your campaign.</h3>
           </div>
-          <InfoPopover title="AI narrative" description="Quick tips to tighten performance against your guardrails." />
+          <Info
+            title="AI narrative"
+            body={(
+              <>
+                <p><strong>How it is used:</strong> Digest coaching notes that summarize the best moves to reach guardrails.</p>
+                <p><strong>What it means:</strong> Insights combine synthetic telemetry, channel heuristics, and offer economics.</p>
+              </>
+            )}
+          />
         </header>
         {simResults ? (
           <ul className="space-y-2 text-sm text-slate-300">
@@ -594,6 +809,18 @@ const CampaignDesigner: React.FC = () => {
         <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-3 text-xs text-emerald-200">
           Confidence: {simResults ? 'High — rich digital signals' : 'Awaiting simulation'}
         </div>
+        <button
+          type="button"
+          className={`w-full rounded-full border px-4 py-2 text-sm font-semibold transition ${
+            launchReady
+              ? 'border-emerald-500/60 bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30'
+              : 'border-slate-700 bg-slate-900/60 text-slate-500'
+          }`}
+          onClick={() => setLaunchOpen(true)}
+          disabled={!launchReady}
+        >
+          Launch to Execution Hub
+        </button>
         <details className="text-xs text-slate-400">
           <summary className="flex cursor-pointer items-center gap-2 text-emerald-300">
             Supporting data
@@ -628,6 +855,83 @@ const CampaignDesigner: React.FC = () => {
           disabled={!simResults}
         />
       </div>
+      {launchOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm">
+          <div className="w-full max-w-xl rounded-3xl border border-emerald-500/40 bg-slate-950/95 p-6 shadow-emerald-500/20">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-lg font-semibold text-white">Launch to Execution Hub</h3>
+                <p className="text-sm text-slate-300">Confirm the cohorts, mix, and guardrails you are sending into activation.</p>
+              </div>
+              <button
+                type="button"
+                className="text-sm text-slate-400 hover:text-slate-200"
+                onClick={() => setLaunchOpen(false)}
+              >
+                Close
+              </button>
+            </div>
+            <div className="mt-4 space-y-4 text-sm text-slate-200">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-slate-400">Cohorts</p>
+                <ul className="mt-1 space-y-1">
+                  {aggregatedCohorts.map((cohort) => (
+                    <li key={cohort.id} className="flex items-center justify-between gap-3">
+                      <span>{cohort.name}</span>
+                      <span className="text-xs text-slate-400">{cohort.size.toLocaleString()} ppl</span>
+                    </li>
+                  ))}
+                  {aggregatedCohorts.length === 0 ? <li>No cohorts selected.</li> : null}
+                </ul>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-slate-400">Channel mix</p>
+                <div className="mt-1 grid grid-cols-2 gap-2">
+                  {channelKeyList.map((key) => (
+                    <span key={key} className="flex items-center justify-between rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">
+                      <span>{key}</span>
+                      <span>{Math.round((aggregatedChannels[key] ?? 0) * 100)}%</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-slate-400">Offer snapshot</p>
+                <div className="mt-1 grid grid-cols-2 gap-2">
+                  <span className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">Price ${aggregatedOffer.price.toFixed(2)}</span>
+                  <span className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">Promo {aggregatedOffer.promoMonths} mo / ${aggregatedOffer.promoValue}</span>
+                  <span className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">Device subsidy ${aggregatedOffer.deviceSubsidy}</span>
+                  <span className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">Budget ${campaign.budgetTotal.toLocaleString()}</span>
+                </div>
+              </div>
+              <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-3 text-xs text-slate-300">
+                Guardrails: CAC ≤ {campaign.guardrails.cacCeiling ? `$${campaign.guardrails.cacCeiling.toLocaleString()}` : '—'} • Payback target {campaign.guardrails.paybackTarget ? `${campaign.guardrails.paybackTarget} mo` : '—'}
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                className="rounded-full border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 hover:border-slate-500"
+                onClick={() => setLaunchOpen(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={`rounded-full border px-4 py-2 text-sm font-semibold transition ${
+                  launchReady
+                    ? 'border-emerald-500/60 bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30'
+                    : 'border-slate-700 bg-slate-900/60 text-slate-500'
+                }`}
+                onClick={confirmLaunch}
+                disabled={!launchReady}
+              >
+                Launch campaign
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/app/routes/CampaignDesigner.tsx
+++ b/src/app/routes/CampaignDesigner.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import InfoPopover from '../../components/InfoPopover';
 import KpiTile from '../../components/KpiTile';
 import SelectionTray from '../../components/SelectionTray';
 import { simulateCampaign, AudienceSimInput } from '../../sim/tinySim';
@@ -117,35 +118,108 @@ const CampaignDesigner: React.FC = () => {
     });
   }, [savedScenarios, simResults]);
 
+  const exportSummary = React.useCallback(() => {
+    if (!simResults) return;
+    const audienceLines = campaign.audienceIds
+      .map((id) => {
+        const entry = microMap.get(id);
+        if (!entry) return null;
+        const segment = segments.find((seg) => seg.id === entry.parentId);
+        if (!segment) return null;
+        return `- ${segment.name} • ${entry.data.name}`;
+      })
+      .filter(Boolean) as string[];
+    const summaryLines = [
+      'Campaign Summary',
+      `Total budget: $${campaign.budgetTotal.toLocaleString()}`,
+      'Audiences:',
+      ...audienceLines,
+      '',
+      `Payback: ${typeof simResults.blended.paybackMonths === 'number' ? `${simResults.blended.paybackMonths} months` : simResults.blended.paybackMonths}`,
+      `12-month GM: $${simResults.blended.gm12m.toLocaleString()}`,
+      `Conversion: ${(simResults.blended.conversionRate * 100).toFixed(1)}%`,
+      `Net adds: ${simResults.blended.netAdds.toLocaleString()}`,
+      '',
+      `Winning plan: ${winning ? winning.label : 'Current plan'}`
+    ];
+    const blob = new Blob([summaryLines.join('\n')], { type: 'application/pdf' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'campaign-summary.pdf';
+    link.click();
+    URL.revokeObjectURL(url);
+  }, [campaign.audienceIds, campaign.budgetTotal, microMap, segments, simResults, winning]);
+
   return (
-    <div className="grid grid-cols-[280px_1fr_300px] gap-6">
-      <aside className="flex flex-col gap-4">
-        <div className="card border border-slate-800 p-4">
-          <p className="text-xs uppercase tracking-wide text-emerald-400">How to use</p>
-          <p className="mt-2 text-sm text-slate-300">
-            Design and simulate offers, bundles, and channel mixes for your selected sub-segments. Adjust inputs to see conversion, CAC payback, and margin update in real time.
-          </p>
-        </div>
-        <div className="card border border-slate-800 p-4">
-          <h3 className="text-sm font-semibold text-white">Audiences</h3>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {campaign.audienceIds.map((id) => {
-              const entry = microMap.get(id);
-              const segment = entry ? segments.find((seg) => seg.id === entry.parentId) : undefined;
-              return (
-                <span key={id} className="info-chip">
-                  {segment?.name} • {entry?.data.name}
-                </span>
-              );
-            })}
+    <div className="space-y-6">
+      <div className="card border border-emerald-500/20 bg-slate-900/70 p-5">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-white">Offering & Campaign Designer</h1>
+            <p className="mt-2 max-w-2xl text-sm text-slate-300">
+              Design offers, channel mixes, and budgets for selected micro-segments, then simulate impact before exporting a leadership-ready summary.
+            </p>
           </div>
-          <p className="mt-3 text-[11px] uppercase tracking-wide text-emerald-400">Primary data sources (est.): Synth Cohort Econ / Campaign Designer Logs</p>
+          <InfoPopover
+            title="Campaign Designer overview"
+            description="Fine-tune pricing, promos, and channels while tinySim updates payback, margin, and net adds in real time."
+          />
         </div>
+        <div className="mt-4 grid gap-3 text-sm text-slate-200 md:grid-cols-3">
+          <div className="flex items-start gap-2">
+            <InfoPopover title="Align inputs" description="Adjust offer and channel levers to hit guardrails." />
+            <span>Use the left rail controls to tweak pricing, promos, and channel allocations.</span>
+          </div>
+          <div className="flex items-start gap-2">
+            <InfoPopover title="Simulate instantly" description="KPIs update as soon as you change assumptions." />
+            <span>Watch payback, margin, and conversion respond immediately in the dashboard.</span>
+          </div>
+          <div className="flex items-start gap-2">
+            <InfoPopover title="Share the story" description="Export a polished summary for stakeholders." />
+            <span>Capture the winning play and export a PDF summary for leadership.</span>
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-[280px_1fr_300px] gap-6">
+        <aside className="flex flex-col gap-4">
+          <div className="card border border-slate-800 p-4">
+            <div className="flex items-center justify-between">
+              <p className="text-xs uppercase tracking-wide text-emerald-400">How to use</p>
+              <InfoPopover title="How to use" description="Start with guardrails, then iterate on offers and channels." />
+            </div>
+            <p className="mt-2 text-sm text-slate-300">
+              Design and simulate offers, bundles, and channel mixes for your selected sub-segments. Adjust inputs to see conversion, CAC payback, and margin update in real time.
+            </p>
+          </div>
+          <div className="card border border-slate-800 p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-white">Audiences</h3>
+              <InfoPopover title="Audiences" description="Micro-segments currently in scope for this campaign." />
+            </div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {campaign.audienceIds.map((id) => {
+                const entry = microMap.get(id);
+                const segment = entry ? segments.find((seg) => seg.id === entry.parentId) : undefined;
+                return (
+                  <span key={id} className="info-chip">
+                    {segment?.name} • {entry?.data.name}
+                  </span>
+                );
+              })}
+            </div>
+          </div>
         <div className="card border border-slate-800 p-4">
-          <h3 className="text-sm font-semibold text-white">Budget & guardrails</h3>
-          <div className="space-y-3 text-sm text-slate-300">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-white">Budget & guardrails</h3>
+            <InfoPopover title="Budget & guardrails" description="Set the constraints that guide the simulation." />
+          </div>
+          <div className="mt-3 space-y-3 text-sm text-slate-300">
             <div>
-              <label className="text-xs uppercase tracking-wide text-slate-400">Total budget</label>
+              <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+                <span>Total budget</span>
+                <InfoPopover title="Total budget" description="Allocate your overall spend for this campaign." placement="left" />
+              </div>
               <input
                 type="number"
                 value={campaign.budgetTotal}
@@ -155,7 +229,10 @@ const CampaignDesigner: React.FC = () => {
             </div>
             <div className="grid grid-cols-2 gap-2">
               <div>
-                <label className="text-xs uppercase tracking-wide text-slate-400">CAC ceiling</label>
+                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+                  <span>CAC ceiling</span>
+                  <InfoPopover title="CAC ceiling" description="Upper limit for fully-loaded acquisition costs." placement="left" />
+                </div>
                 <input
                   type="number"
                   value={campaign.guardrails.cacCeiling ?? ''}
@@ -164,7 +241,10 @@ const CampaignDesigner: React.FC = () => {
                 />
               </div>
               <div>
-                <label className="text-xs uppercase tracking-wide text-slate-400">Payback target</label>
+                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+                  <span>Payback target</span>
+                  <InfoPopover title="Payback target" description="Desired timeline to recoup CAC." placement="left" />
+                </div>
                 <input
                   type="number"
                   value={campaign.guardrails.paybackTarget ?? ''}
@@ -175,7 +255,10 @@ const CampaignDesigner: React.FC = () => {
             </div>
           </div>
           <details className="mt-3 space-y-2 text-sm text-slate-300">
-            <summary className="cursor-pointer text-xs uppercase tracking-wide text-emerald-400">Advanced assumptions</summary>
+            <summary className="flex cursor-pointer items-center gap-2 text-xs uppercase tracking-wide text-emerald-400">
+              Advanced assumptions
+              <InfoPopover title="Advanced assumptions" description="Prototype keeps these fixed; adjust offline for deeper what-ifs." />
+            </summary>
             <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-400">
               Margin %
               <input
@@ -192,6 +275,46 @@ const CampaignDesigner: React.FC = () => {
         </div>
       </aside>
       <section className="flex flex-col gap-6">
+        <div className="card border border-slate-800 p-5">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="text-lg font-semibold text-white">Campaign concept placeholder</h3>
+              <p className="mt-1 text-sm text-slate-300">Use this visual as a stand-in for the eventual creative cover your team will produce.</p>
+            </div>
+            <InfoPopover title="Campaign concept" description="Placeholder showing how a finalized cover could appear." />
+          </div>
+          <div className="mt-4 grid gap-4 md:grid-cols-[2fr_1fr]">
+            <div className="rounded-2xl border border-emerald-500/30 bg-gradient-to-br from-emerald-500/10 via-slate-900 to-slate-950 p-6 text-white shadow-inner shadow-emerald-500/20">
+              <p className="text-xs uppercase tracking-[0.2em] text-emerald-300">Winning Play</p>
+              <h4 className="mt-3 text-2xl font-semibold">{winning ? winning.label : 'Current plan'}</h4>
+              <p className="mt-2 max-w-md text-sm text-emerald-100">
+                Digital-first bundles for priority micro-segments with tight promo discipline and high-margin channel mix.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-4 text-sm">
+                <div>
+                  <p className="text-xs uppercase text-emerald-200">Payback</p>
+                  <p className="text-lg font-semibold">{simResults ? (typeof simResults.blended.paybackMonths === 'number' ? `${simResults.blended.paybackMonths} mo` : simResults.blended.paybackMonths) : '–'}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase text-emerald-200">12-mo GM</p>
+                  <p className="text-lg font-semibold">{simResults ? `$${simResults.blended.gm12m.toLocaleString()}` : '–'}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase text-emerald-200">Conversion</p>
+                  <p className="text-lg font-semibold">{simResults ? `${(simResults.blended.conversionRate * 100).toFixed(1)}%` : '–'}</p>
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-200">
+              <InfoPopover title="Cover checklist" description="What to include when you produce the real campaign cover." />
+              <ul className="list-disc space-y-2 pl-4">
+                <li>Headline promise and supporting subtext.</li>
+                <li>Audience highlight with hero imagery.</li>
+                <li>Offer snapshot and KPIs for leadership.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
         {simResults ? (
           <div className="grid grid-cols-5 gap-3">
             <KpiTile
@@ -199,8 +322,7 @@ const CampaignDesigner: React.FC = () => {
               value={typeof simResults.blended.paybackMonths === 'number' ? simResults.blended.paybackMonths : simResults.blended.paybackMonths}
               info={{
                 title: 'CAC Payback (months)',
-                description: 'Months until fully-loaded CAC is covered by cumulative contribution.',
-                primarySource: 'Synth Cohort Econ'
+                description: 'Months until fully-loaded CAC is covered by cumulative contribution.'
               }}
             />
             <KpiTile
@@ -208,20 +330,43 @@ const CampaignDesigner: React.FC = () => {
               value={`$${simResults.blended.gm12m.toLocaleString()}`}
               info={{
                 title: '12-Month Incremental Gross Margin',
-                description: 'Gross margin over first 12 months after servicing costs and device amortization.',
-                primarySource: 'Synth Cohort Econ'
+                description: 'Gross margin over first 12 months after servicing costs and device amortization.'
               }}
             />
-            <KpiTile label="Conversion %" value={`${(simResults.blended.conversionRate * 100).toFixed(1)}%`} />
-            <KpiTile label="Net adds" value={simResults.blended.netAdds.toLocaleString()} />
-            <KpiTile label="Margin %" value={`${simResults.blended.marginPct}%`} />
+            <KpiTile
+              label="Conversion %"
+              value={`${(simResults.blended.conversionRate * 100).toFixed(1)}%`}
+              info={{
+                title: 'Conversion rate',
+                description: 'Share of the audience expected to take the offer.'
+              }}
+            />
+            <KpiTile
+              label="Net adds"
+              value={simResults.blended.netAdds.toLocaleString()}
+              info={{
+                title: 'Net subscriber adds',
+                description: 'Projected incremental subscribers gained from this plan.'
+              }}
+            />
+            <KpiTile
+              label="Margin %"
+              value={`${simResults.blended.marginPct}%`}
+              info={{
+                title: 'Margin %',
+                description: 'Fully loaded contribution margin percentage for the plan.'
+              }}
+            />
           </div>
         ) : (
           <div className="card border border-slate-800 p-6 text-center text-sm text-slate-300">Add sub-segments to simulate.</div>
         )}
         <div className="grid grid-cols-2 gap-4">
           <div className="card flex flex-col gap-4 border border-slate-800 p-4">
-            <h3 className="text-lg font-semibold text-white">Performance dashboard</h3>
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-white">Performance dashboard</h3>
+              <InfoPopover title="Performance dashboard" description="Track contribution build and cost breakdowns." />
+            </div>
             {simResults ? (
               <div className="h-48">
                 <ResponsiveContainer width="100%" height="100%">
@@ -248,26 +393,41 @@ const CampaignDesigner: React.FC = () => {
             {simResults ? (
               <div className="grid grid-cols-2 gap-3 text-sm text-slate-300">
                 <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">CAC</p>
-                  <p className="text-lg font-semibold text-white">${simResults.blended.breakdown.cac.toLocaleString()}</p>
+                  <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+                    <span>CAC</span>
+                    <InfoPopover title="Fully-loaded CAC" description="Acquisition costs including channel spend and execution." />
+                  </div>
+                  <p className="mt-1 text-lg font-semibold text-white">${simResults.blended.breakdown.cac.toLocaleString()}</p>
                 </div>
                 <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Promo cost</p>
-                  <p className="text-lg font-semibold text-white">${simResults.blended.breakdown.promoCost.toLocaleString()}</p>
+                  <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+                    <span>Promo cost</span>
+                    <InfoPopover title="Promo cost" description="Value of incentives applied over the promo window." />
+                  </div>
+                  <p className="mt-1 text-lg font-semibold text-white">${simResults.blended.breakdown.promoCost.toLocaleString()}</p>
                 </div>
                 <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Device subsidy</p>
-                  <p className="text-lg font-semibold text-white">${simResults.blended.breakdown.deviceSubsidy.toLocaleString()}</p>
+                  <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+                    <span>Device subsidy</span>
+                    <InfoPopover title="Device subsidy" description="Upfront device incentives amortized over the term." />
+                  </div>
+                  <p className="mt-1 text-lg font-semibold text-white">${simResults.blended.breakdown.deviceSubsidy.toLocaleString()}</p>
                 </div>
                 <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Execution cost</p>
-                  <p className="text-lg font-semibold text-white">${simResults.blended.breakdown.executionCost.toLocaleString()}</p>
+                  <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+                    <span>Execution cost</span>
+                    <InfoPopover title="Execution cost" description="One-time cost to launch and manage the campaign." />
+                  </div>
+                  <p className="mt-1 text-lg font-semibold text-white">${simResults.blended.breakdown.executionCost.toLocaleString()}</p>
                 </div>
               </div>
             ) : null}
           </div>
           <div className="card flex flex-col gap-4 border border-slate-800 p-4">
-            <h3 className="text-lg font-semibold text-white">Offer & channel designer</h3>
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-white">Offer & channel designer</h3>
+              <InfoPopover title="Designer" description="Adjust levers for each audience to see immediate impact." />
+            </div>
             {campaign.audienceIds.map((audienceId) => {
               const entry = microMap.get(audienceId);
               const segment = entry ? segments.find((seg) => seg.id === entry.parentId) : undefined;
@@ -275,7 +435,10 @@ const CampaignDesigner: React.FC = () => {
               const mix = campaign.channelMixByAudience[audienceId] ?? {};
               return (
                 <div key={audienceId} className="rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-200">
-                  <h4 className="text-base font-semibold text-white">{segment?.name} — {entry?.data.name}</h4>
+                  <div className="flex items-center justify-between">
+                    <h4 className="text-base font-semibold text-white">{segment?.name} — {entry?.data.name}</h4>
+                    <InfoPopover title="Audience card" description="Tweak offer and channel weightings for this audience." placement="left" />
+                  </div>
                   <div className="mt-3 grid grid-cols-2 gap-3">
                     <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-400">
                       Monthly price (${currentOffer.monthlyPrice})
@@ -320,7 +483,10 @@ const CampaignDesigner: React.FC = () => {
                     </label>
                   </div>
                   <div className="mt-4 space-y-2">
-                    <p className="text-xs uppercase tracking-wide text-slate-400">Channel allocation</p>
+                    <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+                      <span>Channel allocation</span>
+                      <InfoPopover title="Channel allocation" description="Drag sliders to rebalance spend across touchpoints." placement="left" />
+                    </div>
                     {channels.map((channel) => (
                       <div key={channel.id} className="flex items-center gap-3 text-xs text-slate-300">
                         <span className="w-24 text-slate-400">{channel.name}</span>
@@ -343,7 +509,10 @@ const CampaignDesigner: React.FC = () => {
         </div>
         <div className="card flex flex-col gap-4 border border-slate-800 p-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-lg font-semibold text-white">Scenario comparison</h3>
+            <div className="flex items-center gap-2">
+              <h3 className="text-lg font-semibold text-white">Scenario comparison</h3>
+              <InfoPopover title="Scenario comparison" description="Save variations and compare outcomes." />
+            </div>
             <button
               onClick={saveScenario}
               className="rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-600"
@@ -368,8 +537,11 @@ const CampaignDesigner: React.FC = () => {
         </div>
         {winning ? (
           <div className="card flex items-center justify-between border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">
-            <div>
-              <p className="text-xs uppercase tracking-wide">Winning play</p>
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <p className="text-xs uppercase tracking-wide">Winning play</p>
+                <InfoPopover title="Winning play" description="Snapshot of the scenario delivering the fastest payback." />
+              </div>
               <p className="text-lg font-semibold text-white">{winning.label}</p>
               <p>
                 {typeof winning.payback === 'number' ? `${winning.payback} mo` : winning.payback} payback • ${winning.gm12.toLocaleString()} GM • {(winning.conversion * 100).toFixed(1)}% conversion
@@ -382,9 +554,12 @@ const CampaignDesigner: React.FC = () => {
         ) : null}
       </section>
       <aside className="card flex h-full flex-col gap-4 border border-slate-800 p-4">
-        <header>
-          <p className="text-xs uppercase tracking-wide text-emerald-400">AI narrative & insights</p>
-          <h3 className="text-lg font-semibold text-white">Here’s how to optimize your campaign.</h3>
+        <header className="flex items-start justify-between gap-2">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-emerald-400">AI narrative & insights</p>
+            <h3 className="text-lg font-semibold text-white">Here’s how to optimize your campaign.</h3>
+          </div>
+          <InfoPopover title="AI narrative" description="Quick tips to tighten performance against your guardrails." />
         </header>
         {simResults ? (
           <ul className="space-y-2 text-sm text-slate-300">
@@ -399,8 +574,11 @@ const CampaignDesigner: React.FC = () => {
           Confidence: {simResults ? 'High — rich digital signals' : 'Awaiting simulation'}
         </div>
         <details className="text-xs text-slate-400">
-          <summary className="cursor-pointer text-emerald-300">Supporting data</summary>
-          <p className="mt-2">Primary data sources (est.): Synth Cohort Econ / Channel Benchmarks / Offer Lab</p>
+          <summary className="flex cursor-pointer items-center gap-2 text-emerald-300">
+            Supporting data
+            <InfoPopover title="Supporting data" description="Lists the synthetic sources informing this view." />
+          </summary>
+          <p className="mt-2">Synth Cohort Econ / Channel Benchmarks / Offer Lab</p>
         </details>
       </aside>
       <div className="col-span-3">
@@ -424,17 +602,8 @@ const CampaignDesigner: React.FC = () => {
             { label: '12-mo GM', value: '–' },
             { label: 'Net adds', value: '–' }
           ]}
-          ctaLabel="Export JSON"
-          onCta={() => {
-            const payload = JSON.stringify({ campaign, results: simResults }, null, 2);
-            const blob = new Blob([payload], { type: 'application/json' });
-            const url = URL.createObjectURL(blob);
-            const link = document.createElement('a');
-            link.href = url;
-            link.download = 'campaign-plan.json';
-            link.click();
-            URL.revokeObjectURL(url);
-          }}
+          ctaLabel="Export Summary (PDF)"
+          onCta={exportSummary}
           disabled={!simResults}
         />
       </div>

--- a/src/app/routes/MarketRadar.tsx
+++ b/src/app/routes/MarketRadar.tsx
@@ -1,0 +1,641 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import BubbleChart, { BubblePoint } from '../../components/BubbleChart';
+import InfoPopover from '../../components/InfoPopover';
+import MapView, { GeoNode } from '../../components/MapView';
+import PillToggle from '../../components/PillToggle';
+import RightRail from '../../components/RightRail';
+import SegmentTile from '../../components/SegmentTile';
+import SelectionTray from '../../components/SelectionTray';
+import { parseIntent } from '../../lib/intentParser';
+import { simulateCampaign } from '../../sim/tinySim';
+import { useGlobalStore } from '../../store/global';
+
+const geoTree: GeoNode[] = [
+  {
+    id: 'ca',
+    name: 'California',
+    value: 82,
+    meta: { region: 'west' },
+    children: [
+      {
+        id: 'sf-dma',
+        name: 'San Francisco Bay DMA',
+        value: 74,
+        meta: { dma: 'san francisco' },
+        children: [
+          { id: '941', name: 'ZIP3 941', value: 68, meta: { zip3: '941' } },
+          { id: '945', name: 'ZIP3 945', value: 72, meta: { zip3: '945' } },
+          { id: '947', name: 'ZIP3 947', value: 65, meta: { zip3: '947' } }
+        ]
+      },
+      {
+        id: 'la-dma',
+        name: 'Los Angeles DMA',
+        value: 80,
+        meta: { dma: 'los angeles' },
+        children: [
+          { id: '900', name: 'ZIP3 900', value: 76, meta: { zip3: '900' } },
+          { id: '902', name: 'ZIP3 902', value: 70, meta: { zip3: '902' } },
+          { id: '913', name: 'ZIP3 913', value: 65, meta: { zip3: '913' } }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'tx',
+    name: 'Texas',
+    value: 75,
+    meta: { region: 'south' },
+    children: [
+      {
+        id: 'dal-dma',
+        name: 'Dallas-Fort Worth DMA',
+        value: 68,
+        meta: { dma: 'dallas' },
+        children: [
+          { id: '750', name: 'ZIP3 750', value: 63, meta: { zip3: '750' } },
+          { id: '752', name: 'ZIP3 752', value: 60, meta: { zip3: '752' } },
+          { id: '761', name: 'ZIP3 761', value: 58, meta: { zip3: '761' } }
+        ]
+      },
+      {
+        id: 'aus-dma',
+        name: 'Austin DMA',
+        value: 72,
+        meta: { dma: 'austin' },
+        children: [
+          { id: '786', name: 'ZIP3 786', value: 69, meta: { zip3: '786' } },
+          { id: '787', name: 'ZIP3 787', value: 74, meta: { zip3: '787' } },
+          { id: '765', name: 'ZIP3 765', value: 65, meta: { zip3: '765' } }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'ny',
+    name: 'New York',
+    value: 78,
+    meta: { region: 'northeast' },
+    children: [
+      {
+        id: 'nyc-dma',
+        name: 'NYC DMA',
+        value: 82,
+        meta: { dma: 'new york' },
+        children: [
+          { id: '100', name: 'ZIP3 100', value: 80, meta: { zip3: '100' } },
+          { id: '101', name: 'ZIP3 101', value: 70, meta: { zip3: '101' } },
+          { id: '112', name: 'ZIP3 112', value: 68, meta: { zip3: '112' } }
+        ]
+      }
+    ]
+  }
+];
+
+type ViewMode = 'market' | 'map' | 'compare';
+
+type FilterField = {
+  id: string;
+  label: string;
+  type: 'select' | 'range' | 'text';
+  options?: string[];
+  placeholder?: string;
+  info: { title: string; description: string; primarySource: string };
+};
+
+type FilterGroup = {
+  id: string;
+  label: string;
+  fields: FilterField[];
+  source: string;
+};
+
+const filterGroups: FilterGroup[] = [
+  {
+    id: 'people-place',
+    label: 'People & Place',
+    source: 'Converge CONSUMER / HundredX / Recon / CSP 1P (synthetic)',
+    fields: [
+      {
+        id: 'region',
+        label: 'Region focus',
+        type: 'select',
+        options: ['National', 'Urban', 'Suburban', 'Rural', 'West', 'South', 'Northeast'],
+        info: {
+          title: 'Region filter',
+          description: 'Focus the cohort list by geography or environment-level markers.',
+          primarySource: 'Converge CONSUMER (synthetic)'
+        }
+      },
+      {
+        id: 'minSize',
+        label: 'Minimum cohort size',
+        type: 'range',
+        info: {
+          title: 'Cohort size threshold',
+          description: 'Use to limit results to larger targetable audiences.',
+          primarySource: 'Synth Cohort Econ'
+        }
+      }
+    ]
+  },
+  {
+    id: 'motivation',
+    label: 'Motivation & Mindset',
+    source: 'Recon Qual Synth / Sentiment Signals',
+    fields: [
+      {
+        id: 'priceSensitivity',
+        label: 'Price sensitivity',
+        type: 'select',
+        options: ['Any', 'Low', 'Medium', 'High'],
+        info: {
+          title: 'Price Sensitivity',
+          description: 'Relative importance of price versus other triggers for this cohort.',
+          primarySource: 'Recon Sentiment (synthetic)'
+        }
+      },
+      {
+        id: 'switchLikelihood',
+        label: 'Likelihood to switch',
+        type: 'select',
+        options: ['Any', 'Elevated', 'High'],
+        info: {
+          title: 'Switch likelihood',
+          description: 'Qualitative assessment of how likely members are to change providers.',
+          primarySource: 'Churn Propensity Model (synthetic)'
+        }
+      }
+    ]
+  },
+  {
+    id: 'behaviors',
+    label: 'Behaviors & Interests',
+    source: 'App Usage Graph / OTT Panels',
+    fields: [
+      {
+        id: 'streaming',
+        label: 'Streaming usage',
+        type: 'select',
+        options: ['Any', 'Light', 'Moderate', 'Heavy'],
+        info: {
+          title: 'Streaming usage',
+          description: 'Levels of video/OTT consumption and device reliance.',
+          primarySource: 'OTT Behavioral Panel (synthetic)'
+        }
+      },
+      {
+        id: 'bundlePropensity',
+        label: 'Bundle propensity',
+        type: 'select',
+        options: ['Any', 'Moderate', 'High'],
+        info: {
+          title: 'Bundle propensity',
+          description: 'Willingness to add adjacent services when incented.',
+          primarySource: 'Cross-sell Model (synthetic)'
+        }
+      }
+    ]
+  },
+  {
+    id: 'channels',
+    label: 'Channels & Reachability',
+    source: 'Engagement Graph / Campaign 1P',
+    fields: [
+      {
+        id: 'preferredChannel',
+        label: 'Preferred channel',
+        type: 'select',
+        options: ['Any', 'Search', 'Social', 'Retail', 'Email'],
+        info: {
+          title: 'Preferred channel',
+          description: 'Channel most likely to capture attention for this cohort.',
+          primarySource: 'Engagement Graph (synthetic)'
+        }
+      }
+    ]
+  }
+];
+
+const defaultChannelMix = {
+  'ch-search': 0.32,
+  'ch-social': 0.24,
+  'ch-email': 0.16,
+  'ch-retail': 0.18,
+  'ch-field': 0.1
+};
+
+const MarketRadar: React.FC = () => {
+  const navigate = useNavigate();
+  const segments = useGlobalStore((s) => s.segments);
+  const microSegmentsByParent = useGlobalStore((s) => s.microSegmentsByParent);
+  const offers = useGlobalStore((s) => s.offers);
+  const channels = useGlobalStore((s) => s.channels);
+  const assumptions = useGlobalStore((s) => s.assumptions);
+  const activeFilters = useGlobalStore((s) => s.activeFilters);
+  const cartSegmentIds = useGlobalStore((s) => s.cartSegmentIds);
+  const setFilters = useGlobalStore((s) => s.setFilters);
+  const setRecommended = useGlobalStore((s) => s.setRecommendedSegmentIds);
+  const addToCart = useGlobalStore((s) => s.addSegmentToCart);
+  const removeFromCart = useGlobalStore((s) => s.removeSegmentFromCart);
+  const setActiveSegment = useGlobalStore((s) => s.setActiveSegment);
+  const activeSegmentId = useGlobalStore((s) => s.activeSegmentId);
+
+  const [view, setView] = React.useState<ViewMode>('market');
+  const [command, setCommand] = React.useState('');
+  const [intentSummary, setIntentSummary] = React.useState('');
+
+  const computeSegmentSim = React.useCallback(
+    (segmentId: string) => {
+      const segment = segments.find((s) => s.id === segmentId);
+      if (!segment) return { payback: 9, gm12: 240, netAdds: 1200, opportunity: 55, conversion: 0.08 };
+      const microSegments = microSegmentsByParent[segmentId] ?? [];
+      const totalWeight = microSegments.reduce((sum, micro) => sum + micro.sizeShare, 0) || 1;
+      const normalized = microSegments.map((micro) => ({
+        ...micro,
+        sizeShare: micro.sizeShare / totalWeight
+      }));
+      const audiences = normalized.map((micro) => ({
+        micro,
+        segmentSize: segment.size,
+        offer: offers[0],
+        channelMix: defaultChannelMix,
+        assumptions,
+        channels
+      }));
+      const { blended } = simulateCampaign({ audiences });
+      return {
+        payback: blended.paybackMonths,
+        gm12: blended.gm12m,
+        netAdds: blended.netAdds,
+        opportunity: normalized.reduce((score, micro) => score + micro.attractiveness * micro.sizeShare, 0) * 100,
+        conversion: blended.conversionRate
+      };
+    },
+    [assumptions, channels, microSegmentsByParent, offers, segments]
+  );
+
+  const rankedSegments = React.useMemo(() => {
+    const filtered = segments
+      .map((segment) => ({
+        segment,
+        sim: computeSegmentSim(segment.id)
+      }))
+      .filter(({ segment }) => {
+        if (activeFilters.region && activeFilters.region !== 'national') {
+          const region = String(activeFilters.region).toLowerCase();
+          if (!segment.region.toLowerCase().includes(region)) {
+            return false;
+          }
+        }
+        if (activeFilters.minSize && segment.size < Number(activeFilters.minSize)) {
+          return false;
+        }
+        if (activeFilters.priceSensitivity) {
+          const desired = String(activeFilters.priceSensitivity).toLowerCase();
+          if (desired !== 'any') {
+            if (desired === 'high' && segment.priceSensitivity < 0.7) return false;
+            if (desired === 'medium' && (segment.priceSensitivity < 0.45 || segment.priceSensitivity > 0.7)) return false;
+            if (desired === 'low' && segment.priceSensitivity >= 0.45) return false;
+          }
+        }
+        return true;
+      })
+      .sort((a, b) => b.sim.opportunity - a.sim.opportunity)
+      .slice(0, 9);
+    setRecommended(filtered.map(({ segment }) => segment.id));
+    return filtered;
+  }, [activeFilters, computeSegmentSim, segments, setRecommended]);
+
+  const bubbleData: BubblePoint[] = rankedSegments.map(({ segment, sim }) => ({
+    id: segment.id,
+    opportunity: Math.min(100, sim.opportunity),
+    size: segment.size,
+    netAdds: sim.netAdds,
+    category: segment.region
+  }));
+
+  const handleCommand = () => {
+    const { filters, summary } = parseIntent(command);
+    setFilters(filters);
+    setIntentSummary(summary);
+  };
+
+  const selectionItems = cartSegmentIds.map((id) => {
+    const segment = segments.find((s) => s.id === id);
+    return { id, label: segment?.name ?? id, subtitle: segment ? `${(segment.size / 1000).toFixed(0)}k HHs` : '' };
+  });
+
+  const selectionMetrics = React.useMemo(() => {
+    if (!cartSegmentIds.length) {
+      return [
+        { label: 'Total size', value: '0' },
+        { label: 'Blended payback', value: '–' },
+        { label: '12-mo GM', value: '–' }
+      ];
+    }
+    let totalSize = 0;
+    let totalGm = 0;
+    let totalNet = 0;
+    let weightedPayback = 0;
+    cartSegmentIds.forEach((id) => {
+      const segment = segments.find((s) => s.id === id);
+      if (!segment) return;
+      const sim = computeSegmentSim(id);
+      const payback = typeof sim.payback === 'number' ? sim.payback : 24;
+      totalSize += segment.size;
+      totalGm += sim.gm12 * segment.size;
+      totalNet += sim.netAdds;
+      weightedPayback += payback * segment.size;
+    });
+    return [
+      { label: 'Total size', value: `${totalSize.toLocaleString()} HHs` },
+      { label: 'Blended payback', value: totalSize ? `${Math.round(weightedPayback / totalSize)} mo` : '–' },
+      { label: '12-mo GM', value: `$${totalSize ? Math.round(totalGm / totalSize).toLocaleString() : '–'}` }
+    ];
+  }, [cartSegmentIds, computeSegmentSim, segments]);
+
+  const activeSegment = rankedSegments.find(({ segment }) => segment.id === activeSegmentId) ?? rankedSegments[0];
+
+  React.useEffect(() => {
+    if (rankedSegments.length && (!activeSegmentId || !rankedSegments.some(({ segment }) => segment.id === activeSegmentId))) {
+      setActiveSegment(rankedSegments[0].segment.id);
+    }
+  }, [activeSegmentId, rankedSegments, setActiveSegment]);
+
+  const rightRailSections = React.useMemo(() => {
+    if (!activeSegment) return [];
+    const segment = activeSegment.segment;
+    return [
+      {
+        id: 'quant',
+        title: 'Quant snapshot',
+        body: (
+          <ul className="space-y-1">
+            <li>Size: {segment.size.toLocaleString()} households</li>
+            <li>Growth velocity: {(segment.valueSensitivity * 120).toFixed(0)} index</li>
+            <li>Cross-shop rate: {(segment.priceSensitivity * 90).toFixed(0)} index</li>
+            <li>Churn pressure: {(segment.priceSensitivity * 100).toFixed(0)} index</li>
+          </ul>
+        )
+      },
+      {
+        id: 'qual',
+        title: 'Qual insights',
+        body: (
+          <ul className="list-disc space-y-1 pl-4">
+            <li>Why it works: {segment.notes}</li>
+            <li>Trigger: {segment.traits[0]}</li>
+            <li>Mindset: {segment.traits[1]}</li>
+          </ul>
+        )
+      },
+      {
+        id: 'competitive',
+        title: 'Competitive context',
+        body: (
+          <ul className="space-y-1">
+            <li>Primary rival: Coverage gaps exploited by BetaTel</li>
+            <li>Local promo intensity: {Math.round(activeSegment.sim.opportunity / 1.6)} index</li>
+            <li>Network perception: {Math.round(segment.valueSensitivity * 100)} / 100</li>
+          </ul>
+        )
+      },
+      {
+        id: 'behaviors',
+        title: 'Behavioral signals',
+        body: (
+          <ul className="space-y-1">
+            {segment.traits.map((trait) => (
+              <li key={trait}>{trait}</li>
+            ))}
+          </ul>
+        )
+      }
+    ];
+  }, [activeSegment]);
+
+  return (
+    <div className="grid grid-cols-[280px_1fr_320px] gap-6">
+      <aside className="flex flex-col gap-4">
+        <div className="card border border-slate-800 p-4">
+          <p className="text-xs uppercase tracking-wide text-emerald-400">How to use</p>
+          <p className="mt-2 text-sm text-slate-300">
+            Filter the population or type a natural-language query. See recommended cohorts, inspect the visualization, and add promising cohorts to your cart.
+          </p>
+        </div>
+        <div className="card border border-slate-800 p-4">
+          <label className="text-xs uppercase tracking-wide text-slate-400">Command bar</label>
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              value={command}
+              onChange={(event) => setCommand(event.target.value)}
+              placeholder="ex: urban cohorts over 200k size"
+              className="flex-1 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
+            />
+            <button
+              onClick={handleCommand}
+              className="rounded-lg bg-emerald-500 px-3 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-600"
+            >
+              Apply
+            </button>
+          </div>
+          {intentSummary ? (
+            <span className="mt-3 inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs text-emerald-200">
+              What changed: {intentSummary}
+            </span>
+          ) : null}
+        </div>
+        {filterGroups.map((group) => (
+          <div key={group.id} className="card border border-slate-800 p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-white">{group.label}</h3>
+              <InfoPopover
+                title={group.label}
+                description={`Filters linked to the ${group.label} framework.`}
+                primarySource={group.source}
+              />
+            </div>
+            <div className="mt-3 space-y-3">
+              {group.fields.map((field) => {
+                const value = activeFilters[field.id] ?? (field.type === 'select' ? field.options?.[0]?.toLowerCase() ?? '' : '');
+                return (
+                  <div key={field.id} className="space-y-1">
+                    <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+                      {field.label}
+                      <InfoPopover {...field.info} placement="left" />
+                    </label>
+                    {field.type === 'select' ? (
+                      <select
+                        value={value}
+                        onChange={(event) => setFilters({ [field.id]: event.target.value.toLowerCase() })}
+                        className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
+                      >
+                        {field.options?.map((option) => (
+                          <option key={option} value={option.toLowerCase()}>
+                            {option}
+                          </option>
+                        ))}
+                      </select>
+                    ) : field.type === 'range' ? (
+                      <input
+                        type="number"
+                        min={0}
+                        value={activeFilters[field.id] ?? ''}
+                        onChange={(event) => setFilters({ [field.id]: event.target.value ? Number(event.target.value) : undefined })}
+                        className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
+                        placeholder="Size in households"
+                      />
+                    ) : (
+                      <input
+                        type="text"
+                        value={activeFilters[field.id] ?? ''}
+                        onChange={(event) => setFilters({ [field.id]: event.target.value })}
+                        className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
+                        placeholder={field.placeholder}
+                      />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+            <p className="mt-3 text-[11px] uppercase tracking-wide text-emerald-400">Primary data source (est.): {group.source}</p>
+          </div>
+        ))}
+      </aside>
+      <section className="flex flex-col gap-6">
+        <PillToggle
+          options={[
+            { id: 'market', label: 'Market View' },
+            { id: 'map', label: 'Competitive Map' },
+            { id: 'compare', label: 'Compare' }
+          ]}
+          value={view}
+          onChange={(value) => setView(value)}
+        />
+        {view === 'market' ? (
+          <>
+            <BubbleChart
+              segments={segments}
+              data={bubbleData}
+              onSelect={(id) => setActiveSegment(id)}
+            />
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+              {rankedSegments.map(({ segment, sim }) => (
+                <SegmentTile
+                  key={segment.id}
+                  name={segment.name}
+                  size={segment.size}
+                  payback={sim.payback}
+                  gm12={sim.gm12}
+                  traits={segment.traits}
+                  rationale={`Opportunity score ${(sim.opportunity / 100).toFixed(2)} • Conversion ${(sim.conversion * 100).toFixed(1)}%`}
+                  selected={cartSegmentIds.includes(segment.id)}
+                  onSelect={(checked) => (checked ? addToCart(segment.id) : removeFromCart(segment.id))}
+                  onAddToCart={() => addToCart(segment.id)}
+                  onSendToStudio={() => {
+                    addToCart(segment.id);
+                    navigate('/segment-studio');
+                  }}
+                  onPin={() => setActiveSegment(segment.id)}
+                />
+              ))}
+            </div>
+          </>
+        ) : null}
+        {view === 'map' ? (
+          <MapView
+            root={geoTree}
+            onSelectRegion={(path) => {
+              const deepest = path[path.length - 1];
+              if (deepest?.meta?.region) {
+                setFilters({ region: deepest.meta.region });
+              }
+              if (deepest?.meta?.dma) {
+                setFilters({ dma: deepest.meta.dma });
+              }
+              if (deepest?.meta?.zip3) {
+                setFilters({ zip3: deepest.meta.zip3 });
+              }
+            }}
+          />
+        ) : null}
+        {view === 'compare' ? (
+          <div className="card flex flex-col gap-4 border border-slate-800 p-4">
+            <h3 className="text-lg font-semibold text-white">Compare cohorts</h3>
+            <p className="text-sm text-slate-300">
+              Quickly compare top cohorts across payback, 12-mo GM, and projected net adds. Use this view when prioritizing a short list.
+            </p>
+            <div className="grid grid-cols-3 gap-3 text-sm">
+              <span className="text-xs uppercase tracking-wide text-slate-400">Cohort</span>
+              <span className="text-xs uppercase tracking-wide text-slate-400">Payback</span>
+              <span className="text-xs uppercase tracking-wide text-slate-400">12-mo GM</span>
+              {rankedSegments.map(({ segment, sim }) => (
+                <React.Fragment key={`compare-${segment.id}`}>
+                  <span className="font-semibold text-white">{segment.name}</span>
+                  <span>{typeof sim.payback === 'number' ? `${sim.payback} mo` : sim.payback}</span>
+                  <span>${sim.gm12.toLocaleString()}</span>
+                </React.Fragment>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </section>
+      {activeSegment ? (
+        <RightRail
+          title={activeSegment.segment.name}
+          subtitle={`ID ${activeSegment.segment.id}`}
+          kpis={[
+            {
+              label: 'Payback (mo)',
+              value: typeof activeSegment.sim.payback === 'number' ? activeSegment.sim.payback : activeSegment.sim.payback,
+              info: {
+                title: 'CAC Payback (months)',
+                description: 'Months until fully-loaded CAC is covered by cumulative contribution.',
+                primarySource: 'Synth Cohort Econ'
+              }
+            },
+            {
+              label: '12-mo GM',
+              value: `$${activeSegment.sim.gm12.toLocaleString()}`,
+              info: {
+                title: '12-Month Incremental Gross Margin',
+                description: 'Gross margin over first 12 months after servicing costs and device amortization.',
+                primarySource: 'Synth Cohort Econ'
+              }
+            }
+          ]}
+          sections={rightRailSections}
+          action={
+            <button
+              onClick={() => {
+                addToCart(activeSegment.segment.id);
+                navigate('/segment-studio');
+              }}
+              className="w-full rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-600"
+            >
+              Send to Segment Studio
+            </button>
+          }
+        />
+      ) : (
+        <div className="card border border-slate-800 p-4 text-sm text-slate-300">
+          Select a cohort to see details.
+        </div>
+      )}
+      <div className="col-span-3">
+        <SelectionTray
+          title="Cohorts in cart"
+          items={selectionItems}
+          metrics={selectionMetrics}
+          ctaLabel="Send to Segment Studio"
+          onCta={() => navigate('/segment-studio')}
+          disabled={!cartSegmentIds.length}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MarketRadar;

--- a/src/app/routes/MarketRadar.tsx
+++ b/src/app/routes/MarketRadar.tsx
@@ -101,14 +101,14 @@ type FilterField = {
   type: 'select' | 'range' | 'text';
   options?: string[];
   placeholder?: string;
-  info: { title: string; description: string; primarySource: string };
+  info: { title: string; description: string; primarySource?: string };
 };
 
 type FilterGroup = {
   id: string;
   label: string;
   fields: FilterField[];
-  source: string;
+  source?: string;
 };
 
 const filterGroups: FilterGroup[] = [
@@ -371,6 +371,10 @@ const MarketRadar: React.FC = () => {
       {
         id: 'quant',
         title: 'Quant snapshot',
+        info: {
+          title: 'Quant snapshot',
+          description: 'Key metrics to size and score the selected cohort.'
+        },
         body: (
           <ul className="space-y-1">
             <li>Size: {segment.size.toLocaleString()} households</li>
@@ -383,6 +387,10 @@ const MarketRadar: React.FC = () => {
       {
         id: 'qual',
         title: 'Qual insights',
+        info: {
+          title: 'Qual insights',
+          description: 'Plain-language cues to explain the opportunity drivers.'
+        },
         body: (
           <ul className="list-disc space-y-1 pl-4">
             <li>Why it works: {segment.notes}</li>
@@ -394,6 +402,10 @@ const MarketRadar: React.FC = () => {
       {
         id: 'competitive',
         title: 'Competitive context',
+        info: {
+          title: 'Competitive context',
+          description: 'Understand who else is active and how we can win.'
+        },
         body: (
           <ul className="space-y-1">
             <li>Primary rival: Coverage gaps exploited by BetaTel</li>
@@ -405,6 +417,10 @@ const MarketRadar: React.FC = () => {
       {
         id: 'behaviors',
         title: 'Behavioral signals',
+        info: {
+          title: 'Behavioral signals',
+          description: 'Signals that describe how the cohort shows up in market.'
+        },
         body: (
           <ul className="space-y-1">
             {segment.traits.map((trait) => (
@@ -417,222 +433,263 @@ const MarketRadar: React.FC = () => {
   }, [activeSegment]);
 
   return (
-    <div className="grid grid-cols-[280px_1fr_320px] gap-6">
-      <aside className="flex flex-col gap-4">
-        <div className="card border border-slate-800 p-4">
-          <p className="text-xs uppercase tracking-wide text-emerald-400">How to use</p>
-          <p className="mt-2 text-sm text-slate-300">
-            Filter the population or type a natural-language query. See recommended cohorts, inspect the visualization, and add promising cohorts to your cart.
-          </p>
-        </div>
-        <div className="card border border-slate-800 p-4">
-          <label className="text-xs uppercase tracking-wide text-slate-400">Command bar</label>
-          <div className="mt-2 flex items-center gap-2">
-            <input
-              value={command}
-              onChange={(event) => setCommand(event.target.value)}
-              placeholder="ex: urban cohorts over 200k size"
-              className="flex-1 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
-            />
-            <button
-              onClick={handleCommand}
-              className="rounded-lg bg-emerald-500 px-3 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-600"
-            >
-              Apply
-            </button>
-          </div>
-          {intentSummary ? (
-            <span className="mt-3 inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs text-emerald-200">
-              What changed: {intentSummary}
-            </span>
-          ) : null}
-        </div>
-        {filterGroups.map((group) => (
-          <div key={group.id} className="card border border-slate-800 p-4">
-            <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-white">{group.label}</h3>
-              <InfoPopover
-                title={group.label}
-                description={`Filters linked to the ${group.label} framework.`}
-                primarySource={group.source}
-              />
-            </div>
-            <div className="mt-3 space-y-3">
-              {group.fields.map((field) => {
-                const value = activeFilters[field.id] ?? (field.type === 'select' ? field.options?.[0]?.toLowerCase() ?? '' : '');
-                return (
-                  <div key={field.id} className="space-y-1">
-                    <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-                      {field.label}
-                      <InfoPopover {...field.info} placement="left" />
-                    </label>
-                    {field.type === 'select' ? (
-                      <select
-                        value={value}
-                        onChange={(event) => setFilters({ [field.id]: event.target.value.toLowerCase() })}
-                        className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
-                      >
-                        {field.options?.map((option) => (
-                          <option key={option} value={option.toLowerCase()}>
-                            {option}
-                          </option>
-                        ))}
-                      </select>
-                    ) : field.type === 'range' ? (
-                      <input
-                        type="number"
-                        min={0}
-                        value={activeFilters[field.id] ?? ''}
-                        onChange={(event) => setFilters({ [field.id]: event.target.value ? Number(event.target.value) : undefined })}
-                        className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
-                        placeholder="Size in households"
-                      />
-                    ) : (
-                      <input
-                        type="text"
-                        value={activeFilters[field.id] ?? ''}
-                        onChange={(event) => setFilters({ [field.id]: event.target.value })}
-                        className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
-                        placeholder={field.placeholder}
-                      />
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-            <p className="mt-3 text-[11px] uppercase tracking-wide text-emerald-400">Primary data source (est.): {group.source}</p>
-          </div>
-        ))}
-      </aside>
-      <section className="flex flex-col gap-6">
-        <PillToggle
-          options={[
-            { id: 'market', label: 'Market View' },
-            { id: 'map', label: 'Competitive Map' },
-            { id: 'compare', label: 'Compare' }
-          ]}
-          value={view}
-          onChange={(value) => setView(value)}
-        />
-        {view === 'market' ? (
-          <>
-            <BubbleChart
-              segments={segments}
-              data={bubbleData}
-              onSelect={(id) => setActiveSegment(id)}
-            />
-            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-              {rankedSegments.map(({ segment, sim }) => (
-                <SegmentTile
-                  key={segment.id}
-                  name={segment.name}
-                  size={segment.size}
-                  payback={sim.payback}
-                  gm12={sim.gm12}
-                  traits={segment.traits}
-                  rationale={`Opportunity score ${(sim.opportunity / 100).toFixed(2)} • Conversion ${(sim.conversion * 100).toFixed(1)}%`}
-                  selected={cartSegmentIds.includes(segment.id)}
-                  onSelect={(checked) => (checked ? addToCart(segment.id) : removeFromCart(segment.id))}
-                  onAddToCart={() => addToCart(segment.id)}
-                  onSendToStudio={() => {
-                    addToCart(segment.id);
-                    navigate('/segment-studio');
-                  }}
-                  onPin={() => setActiveSegment(segment.id)}
-                />
-              ))}
-            </div>
-          </>
-        ) : null}
-        {view === 'map' ? (
-          <MapView
-            root={geoTree}
-            onSelectRegion={(path) => {
-              const deepest = path[path.length - 1];
-              if (deepest?.meta?.region) {
-                setFilters({ region: deepest.meta.region });
-              }
-              if (deepest?.meta?.dma) {
-                setFilters({ dma: deepest.meta.dma });
-              }
-              if (deepest?.meta?.zip3) {
-                setFilters({ zip3: deepest.meta.zip3 });
-              }
-            }}
-          />
-        ) : null}
-        {view === 'compare' ? (
-          <div className="card flex flex-col gap-4 border border-slate-800 p-4">
-            <h3 className="text-lg font-semibold text-white">Compare cohorts</h3>
-            <p className="text-sm text-slate-300">
-              Quickly compare top cohorts across payback, 12-mo GM, and projected net adds. Use this view when prioritizing a short list.
+    <div className="space-y-6">
+      <div className="card border border-emerald-500/20 bg-slate-900/70 p-5">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-white">Market Radar</h1>
+            <p className="mt-2 max-w-2xl text-sm text-slate-300">
+              Scan synthetic market signals to spot subscriber cohorts worth advancing into deeper design work.
             </p>
-            <div className="grid grid-cols-3 gap-3 text-sm">
-              <span className="text-xs uppercase tracking-wide text-slate-400">Cohort</span>
-              <span className="text-xs uppercase tracking-wide text-slate-400">Payback</span>
-              <span className="text-xs uppercase tracking-wide text-slate-400">12-mo GM</span>
-              {rankedSegments.map(({ segment, sim }) => (
-                <React.Fragment key={`compare-${segment.id}`}>
-                  <span className="font-semibold text-white">{segment.name}</span>
-                  <span>{typeof sim.payback === 'number' ? `${sim.payback} mo` : sim.payback}</span>
-                  <span>${sim.gm12.toLocaleString()}</span>
-                </React.Fragment>
-              ))}
-            </div>
           </div>
-        ) : null}
-      </section>
-      {activeSegment ? (
-        <RightRail
-          title={activeSegment.segment.name}
-          subtitle={`ID ${activeSegment.segment.id}`}
-          kpis={[
-            {
-              label: 'Payback (mo)',
-              value: typeof activeSegment.sim.payback === 'number' ? activeSegment.sim.payback : activeSegment.sim.payback,
-              info: {
-                title: 'CAC Payback (months)',
-                description: 'Months until fully-loaded CAC is covered by cumulative contribution.',
-                primarySource: 'Synth Cohort Econ'
-              }
-            },
-            {
-              label: '12-mo GM',
-              value: `$${activeSegment.sim.gm12.toLocaleString()}`,
-              info: {
-                title: '12-Month Incremental Gross Margin',
-                description: 'Gross margin over first 12 months after servicing costs and device amortization.',
-                primarySource: 'Synth Cohort Econ'
-              }
-            }
-          ]}
-          sections={rightRailSections}
-          action={
-            <button
-              onClick={() => {
-                addToCart(activeSegment.segment.id);
-                navigate('/segment-studio');
-              }}
-              className="w-full rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-600"
-            >
-              Send to Segment Studio
-            </button>
-          }
-        />
-      ) : (
-        <div className="card border border-slate-800 p-4 text-sm text-slate-300">
-          Select a cohort to see details.
+          <InfoPopover
+            title="Market Radar overview"
+            description="Start here to explore the universe, tune filters, and shortlist the strongest cohorts before moving on."
+          />
         </div>
-      )}
-      <div className="col-span-3">
-        <SelectionTray
-          title="Cohorts in cart"
-          items={selectionItems}
-          metrics={selectionMetrics}
-          ctaLabel="Send to Segment Studio"
-          onCta={() => navigate('/segment-studio')}
-          disabled={!cartSegmentIds.length}
-        />
+        <div className="mt-4 grid gap-3 text-sm text-slate-200 md:grid-cols-3">
+          <div className="flex items-start gap-2">
+            <InfoPopover title="Filter quickly" description="Mix structured filters with quick commands to focus the cohort list." />
+            <span>Use filters or the intent bar to zero in on the customers you care most about.</span>
+          </div>
+          <div className="flex items-start gap-2">
+            <InfoPopover title="Visualize opportunity" description="Bubble, map, and compare views highlight scale, payback, and coverage." />
+            <span>Switch views to understand opportunity sizing and geographic hot spots.</span>
+          </div>
+          <div className="flex items-start gap-2">
+            <InfoPopover title="Advance confidently" description="Shortlist promising cohorts so they flow seamlessly into Segment Studio." />
+            <span>Shortlist the frontrunners and send them forward when you are ready to refine.</span>
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-[280px_1fr_320px] gap-6">
+        <aside className="flex flex-col gap-4">
+          <div className="card border border-slate-800 p-4">
+            <div className="flex items-center justify-between">
+              <p className="text-xs uppercase tracking-wide text-emerald-400">Workflow primer</p>
+              <InfoPopover title="Workflow primer" description="Remember the steps: explore, shortlist, then advance." />
+            </div>
+            <p className="mt-2 text-sm text-slate-300">
+              Filter the population or type a natural-language query. See recommended cohorts, inspect the visualization, and shortlist the best fits.
+            </p>
+          </div>
+          <div className="card border border-slate-800 p-4">
+            <div className="flex items-center justify-between">
+              <label className="text-xs uppercase tracking-wide text-slate-400">Command bar</label>
+              <InfoPopover title="Command bar" description="Type a short instruction to automatically adjust filters." />
+            </div>
+            <div className="mt-2 flex items-center gap-2">
+              <input
+                value={command}
+                onChange={(event) => setCommand(event.target.value)}
+                placeholder="ex: urban cohorts over 200k size"
+                className="flex-1 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
+              />
+              <button
+                onClick={handleCommand}
+                className="rounded-lg bg-emerald-500 px-3 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-600"
+              >
+                Apply
+              </button>
+            </div>
+            {intentSummary ? (
+              <span className="mt-3 inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs text-emerald-200">
+                <InfoPopover title="Intent summary" description="Lists the filters the command adjusted." />
+                What changed: {intentSummary}
+              </span>
+            ) : null}
+          </div>
+          {filterGroups.map((group) => (
+            <div key={group.id} className="card border border-slate-800 p-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-white">{group.label}</h3>
+                <InfoPopover title={group.label} description={`Filters linked to the ${group.label} framework.`} />
+              </div>
+              <div className="mt-3 space-y-3">
+                {group.fields.map((field) => {
+                  const value = activeFilters[field.id] ?? (field.type === 'select' ? field.options?.[0]?.toLowerCase() ?? '' : '');
+                  return (
+                    <div key={field.id} className="space-y-1">
+                      <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+                        {field.label}
+                        <InfoPopover title={field.info.title} description={field.info.description} placement="left" />
+                      </label>
+                      {field.type === 'select' ? (
+                        <select
+                          value={value}
+                          onChange={(event) => setFilters({ [field.id]: event.target.value.toLowerCase() })}
+                          className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
+                        >
+                          {field.options?.map((option) => (
+                            <option key={option} value={option.toLowerCase()}>
+                              {option}
+                            </option>
+                          ))}
+                        </select>
+                      ) : field.type === 'range' ? (
+                        <input
+                          type="number"
+                          min={0}
+                          value={activeFilters[field.id] ?? ''}
+                          onChange={(event) => setFilters({ [field.id]: event.target.value ? Number(event.target.value) : undefined })}
+                          className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
+                          placeholder="Size in households"
+                        />
+                      ) : (
+                        <input
+                          type="text"
+                          value={activeFilters[field.id] ?? ''}
+                          onChange={(event) => setFilters({ [field.id]: event.target.value })}
+                          className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none"
+                          placeholder={field.placeholder}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </aside>
+        <section className="flex flex-col gap-6">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-white">Choose your view</h2>
+            <InfoPopover title="View switcher" description="Toggle perspectives to validate scale, geography, or KPI comparisons." />
+          </div>
+          <PillToggle
+            options={[
+              { id: 'market', label: 'Market View' },
+              { id: 'map', label: 'Competitive Map' },
+              { id: 'compare', label: 'Compare' }
+            ]}
+            value={view}
+            onChange={(value) => setView(value)}
+          />
+          {view === 'market' ? (
+            <>
+              <BubbleChart
+                segments={segments}
+                data={bubbleData}
+                onSelect={(id) => setActiveSegment(id)}
+              />
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-white">Recommended cohorts</h3>
+                <InfoPopover title="Recommended cohorts" description="Shortlist from the live-ranked list below." />
+              </div>
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                {rankedSegments.map(({ segment, sim }) => (
+                  <SegmentTile
+                    key={segment.id}
+                    name={segment.name}
+                    size={segment.size}
+                    payback={sim.payback}
+                    gm12={sim.gm12}
+                    traits={segment.traits}
+                    rationale={`Opportunity score ${(sim.opportunity / 100).toFixed(2)} • Conversion ${(sim.conversion * 100).toFixed(1)}%`}
+                    selected={cartSegmentIds.includes(segment.id)}
+                    onSelect={(checked) => (checked ? addToCart(segment.id) : removeFromCart(segment.id))}
+                    onAddToCart={() => addToCart(segment.id)}
+                    onSendToStudio={() => {
+                      addToCart(segment.id);
+                      navigate('/segment-studio');
+                    }}
+                    onPin={() => setActiveSegment(segment.id)}
+                  />
+                ))}
+              </div>
+            </>
+          ) : null}
+          {view === 'map' ? (
+            <MapView
+              root={geoTree}
+              onSelectRegion={(path) => {
+                const deepest = path[path.length - 1];
+                if (deepest?.meta?.region) {
+                  setFilters({ region: deepest.meta.region });
+                }
+                if (deepest?.meta?.dma) {
+                  setFilters({ dma: deepest.meta.dma });
+                }
+                if (deepest?.meta?.zip3) {
+                  setFilters({ zip3: deepest.meta.zip3 });
+                }
+              }}
+            />
+          ) : null}
+          {view === 'compare' ? (
+            <div className="card flex flex-col gap-4 border border-slate-800 p-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-white">Compare cohorts</h3>
+                <InfoPopover title="Comparison table" description="Line up short-listed cohorts before you commit to a path." />
+              </div>
+              <p className="text-sm text-slate-300">
+                Quickly compare top cohorts across payback, 12-mo GM, and projected net adds. Use this view when prioritizing a short list.
+              </p>
+              <div className="grid grid-cols-3 gap-3 text-sm">
+                <span className="text-xs uppercase tracking-wide text-slate-400">Cohort</span>
+                <span className="text-xs uppercase tracking-wide text-slate-400">Payback</span>
+                <span className="text-xs uppercase tracking-wide text-slate-400">12-mo GM</span>
+                {rankedSegments.map(({ segment, sim }) => (
+                  <React.Fragment key={`compare-${segment.id}`}>
+                    <span className="font-semibold text-white">{segment.name}</span>
+                    <span>{typeof sim.payback === 'number' ? `${sim.payback} mo` : sim.payback}</span>
+                    <span>${sim.gm12.toLocaleString()}</span>
+                  </React.Fragment>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </section>
+        {activeSegment ? (
+          <RightRail
+            title={activeSegment.segment.name}
+            subtitle={`ID ${activeSegment.segment.id}`}
+            kpis={[
+              {
+                label: 'Payback (mo)',
+                value: typeof activeSegment.sim.payback === 'number' ? activeSegment.sim.payback : activeSegment.sim.payback,
+                info: {
+                  title: 'CAC Payback (months)',
+                  description: 'Months until fully-loaded CAC is covered by cumulative contribution.'
+                }
+              },
+              {
+                label: '12-mo GM',
+                value: `$${activeSegment.sim.gm12.toLocaleString()}`,
+                info: {
+                  title: '12-Month Incremental Gross Margin',
+                  description: 'Gross margin over the first year after servicing costs and device amortization.'
+                }
+              }
+            ]}
+            sections={rightRailSections}
+            action={
+              <button
+                onClick={() => {
+                  addToCart(activeSegment.segment.id);
+                  navigate('/segment-studio');
+                }}
+                className="w-full rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-600"
+              >
+                Move to Segment Studio
+              </button>
+            }
+          />
+        ) : (
+          <div className="card border border-slate-800 p-4 text-sm text-slate-300">
+            Select a cohort to see details.
+          </div>
+        )}
+        <div className="col-span-3">
+          <SelectionTray
+            title="Shortlisted cohorts"
+            items={selectionItems}
+            metrics={selectionMetrics}
+            ctaLabel="Move to Segment Studio"
+            onCta={() => navigate('/segment-studio')}
+            disabled={!cartSegmentIds.length}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/routes/SegmentStudio.tsx
+++ b/src/app/routes/SegmentStudio.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import InfoPopover from '../../components/InfoPopover';
 import RightRail from '../../components/RightRail';
 import SelectionTray from '../../components/SelectionTray';
 import SubsegmentTile from '../../components/SubsegmentTile';
@@ -99,146 +100,219 @@ const SegmentStudio: React.FC = () => {
   const recommended = sortedSubsegments[0];
 
   return (
-    <div className="grid grid-cols-[240px_1fr_320px] gap-6">
-      <aside className="flex flex-col gap-4">
-        <div className="card border border-slate-800 p-4">
-          <p className="text-xs uppercase tracking-wide text-emerald-400">How to use</p>
-          <p className="mt-2 text-sm text-slate-300">
-            This view breaks your selected cohort(s) into sub-segments and recommends how to target each. Pick the ones you want to take into the campaign.
-          </p>
-        </div>
-        <div className="card border border-slate-800 p-4">
-          <h3 className="text-sm font-semibold text-white">Source cohorts</h3>
-          <div className="mt-2 space-y-2">
-            {sourceCohorts.map((segment) => (
-              <div key={segment!.id} className="rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-xs text-slate-300">
-                <p className="text-sm font-semibold text-white">{segment!.name}</p>
-                <p>{segment!.size.toLocaleString()} households</p>
-                <p>Primary traits: {segment!.traits.slice(0, 2).join(', ')}</p>
-              </div>
-            ))}
-            {!sourceCohorts.length ? <p className="text-xs text-slate-500">No cohorts yet—head back to Market Radar.</p> : null}
+    <div className="space-y-6">
+      <div className="card border border-emerald-500/20 bg-slate-900/70 p-5">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-white">Segment Studio</h1>
+            <p className="mt-2 max-w-2xl text-sm text-slate-300">
+              Break shortlisted cohorts into micro-segments, highlight the winning play, and choose which audiences move into campaign design.
+            </p>
           </div>
-          <p className="mt-3 text-[11px] uppercase tracking-wide text-emerald-400">Primary data sources (est.): Synth Cohort Econ / Segment Fabric</p>
+          <InfoPopover
+            title="Segment Studio overview"
+            description="Review AI-suggested micro-segments, follow the recommended play, and select the audiences to take forward."
+          />
         </div>
-      </aside>
-      <section className="flex flex-col gap-4">
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          {sortedSubsegments.map((entry) => (
-            <SubsegmentTile
-              key={entry.micro.id}
-              name={`${entry.segment.name} — ${entry.micro.name}`}
-              rank={entry.rank}
-              sizeShare={entry.micro.sizeShare}
-              payback={entry.sim.paybackMonths}
-              gm12={entry.sim.gm12m}
-              traits={entry.micro.traits}
-              rationale={`Attractiveness ${(entry.micro.attractiveness * 100).toFixed(0)} • Conversion ${(entry.sim.conversionRate * 100).toFixed(1)}%`}
-              selected={selectedMicroIds.includes(entry.micro.id)}
-              highlight={topThreeIds.includes(entry.micro.id)}
-              onSelect={(checked) => toggleSelection(entry.micro.id, checked)}
-            />
-          ))}
+        <div className="mt-4 grid gap-3 text-sm text-slate-200 md:grid-cols-3">
+          <div className="flex items-start gap-2">
+            <InfoPopover title="See the breakouts" description="Each cohort is split into micro-segments ranked by attractiveness." />
+            <span>Review the sub-segment tiles to understand size, economics, and traits.</span>
+          </div>
+          <div className="flex items-start gap-2">
+            <InfoPopover title="Follow the play" description="Use the headline recommendation to move quickly." />
+            <span>Start with the suggested action and use the bullets to justify the move.</span>
+          </div>
+          <div className="flex items-start gap-2">
+            <InfoPopover title="Pick the audience" description="Select only the micro-segments you want to simulate later." />
+            <span>Toggle selections and send the right mix to the Campaign Designer.</span>
+          </div>
         </div>
-      </section>
-      {recommended ? (
-        <RightRail
-          title="Targeting strategy"
-          subtitle="AI-assisted recommendation"
-          sections={[
-            {
-              id: 'strategy',
-              title: 'Recommended play',
-              defaultOpen: true,
-              body: (
-                <div className="space-y-2 text-sm">
-                  <p className="font-semibold text-white">Goal</p>
-                  <p>Drive high-value conversions among {recommended.segment.name} using {offer.name} with a heavier digital mix.</p>
-                  <p className="font-semibold text-white">Offer archetype</p>
-                  <p>{offer.name} — ${offer.monthlyPrice}/mo, promo {offer.promoMonths} mo, device subsidy ${offer.deviceSubsidy}.</p>
+      </div>
+      <div className="grid grid-cols-[240px_1fr_320px] gap-6">
+        <aside className="flex flex-col gap-4">
+          <div className="card border border-slate-800 p-4">
+            <div className="flex items-center justify-between">
+              <p className="text-xs uppercase tracking-wide text-emerald-400">Workflow reminder</p>
+              <InfoPopover title="Workflow reminder" description="Trace selections from Market Radar into this studio view." />
+            </div>
+            <p className="mt-2 text-sm text-slate-300">
+              This view breaks your selected cohort(s) into sub-segments and recommends how to target each. Pick the ones you want to take into the campaign.
+            </p>
+          </div>
+          <div className="card border border-slate-800 p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-white">Source cohorts</h3>
+              <InfoPopover title="Source cohorts" description="Shows which cohorts feed these micro-segments." />
+            </div>
+            <div className="mt-2 space-y-2">
+              {sourceCohorts.map((segment) => (
+                <div key={segment!.id} className="rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-xs text-slate-300">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-semibold text-white">{segment!.name}</p>
+                    <InfoPopover title="Cohort details" description="Size and trait summary for this cohort." placement="left" />
+                  </div>
+                  <p>{segment!.size.toLocaleString()} households</p>
+                  <p>Primary traits: {segment!.traits.slice(0, 2).join(', ')}</p>
                 </div>
-              )
-            },
-            {
-              id: 'channels',
-              title: 'Channel mix',
-              body: (
-                <ul className="space-y-1 text-sm">
-                  {Object.entries(defaultMix).map(([channelId, weight]) => (
-                    <li key={channelId}>
-                      {channels.find((ch) => ch.id === channelId)?.name ?? channelId}: {(weight * 100).toFixed(0)}%
-                    </li>
-                  ))}
-                </ul>
-              )
-            },
-            {
-              id: 'why',
-              title: 'Why this works',
-              body: (
-                <ul className="list-disc space-y-1 pl-4 text-sm">
-                  <li>High digital responsiveness — {Math.round(recommended.micro.attractiveness * 100)} index.</li>
-                  <li>Offer bundling aligns with traits: {recommended.micro.traits.slice(0, 2).join(', ')}.</li>
-                  <li>Projected payback {typeof recommended.sim.paybackMonths === 'number' ? `${recommended.sim.paybackMonths} mo` : recommended.sim.paybackMonths}.</li>
-                </ul>
-              )
-            }
-          ]}
-          kpis={[
-            {
-              label: 'Payback (mo)',
-              value: typeof recommended.sim.paybackMonths === 'number' ? recommended.sim.paybackMonths : recommended.sim.paybackMonths,
-              info: {
-                title: 'CAC Payback (months)',
-                description: 'Months until fully-loaded CAC is covered by cumulative contribution.',
-                primarySource: 'Synth Cohort Econ'
+              ))}
+              {!sourceCohorts.length ? <p className="text-xs text-slate-500">No cohorts yet—head back to Market Radar.</p> : null}
+            </div>
+          </div>
+        </aside>
+        <section className="flex flex-col gap-4">
+          {recommended ? (
+            <div className="card border border-emerald-500/30 bg-emerald-500/10 p-5">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-emerald-300">Do this</p>
+                  <h2 className="text-xl font-semibold text-white">
+                    Lead with {offer.name} for {recommended.segment.name} — {recommended.micro.name}
+                  </h2>
+                  <p className="mt-2 text-sm text-emerald-100">
+                    Focus on a digital-first mix and lean on bundled value to win share quickly.
+                  </p>
+                </div>
+                <InfoPopover title="Recommended play" description="Use this starter move and fine-tune as you learn more." />
+              </div>
+              <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-emerald-100">
+                <li>Top-ranked attractiveness ({Math.round(recommended.micro.attractiveness * 100)} index) with strong conversion potential.</li>
+                <li>Offer match: {offer.name} aligns with traits {recommended.micro.traits.slice(0, 2).join(' & ')}.</li>
+                <li>Payback expectation: {typeof recommended.sim.paybackMonths === 'number' ? `${recommended.sim.paybackMonths} months` : recommended.sim.paybackMonths} with ${recommended.sim.gm12m.toLocaleString()} GM.</li>
+              </ul>
+            </div>
+          ) : null}
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-white">Micro-segment recommendations</h3>
+            <InfoPopover title="Micro-segment grid" description="Select the audiences that deserve investment." />
+          </div>
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {sortedSubsegments.map((entry) => (
+              <SubsegmentTile
+                key={entry.micro.id}
+                name={`${entry.segment.name} — ${entry.micro.name}`}
+                rank={entry.rank}
+                sizeShare={entry.micro.sizeShare}
+                payback={entry.sim.paybackMonths}
+                gm12={entry.sim.gm12m}
+                traits={entry.micro.traits}
+                rationale={`Attractiveness ${(entry.micro.attractiveness * 100).toFixed(0)} • Conversion ${(entry.sim.conversionRate * 100).toFixed(1)}%`}
+                selected={selectedMicroIds.includes(entry.micro.id)}
+                highlight={topThreeIds.includes(entry.micro.id)}
+                onSelect={(checked) => toggleSelection(entry.micro.id, checked)}
+              />
+            ))}
+          </div>
+        </section>
+        {recommended ? (
+          <RightRail
+            title="Targeting strategy"
+            subtitle="AI-assisted recommendation"
+            sections={[
+              {
+                id: 'strategy',
+                title: 'Recommended play',
+                defaultOpen: true,
+                info: {
+                  title: 'Recommended play',
+                  description: 'Understand the core action suggested for this audience.'
+                },
+                body: (
+                  <div className="space-y-2 text-sm">
+                    <p className="font-semibold text-white">Goal</p>
+                    <p>Drive high-value conversions among {recommended.segment.name} using {offer.name} with a heavier digital mix.</p>
+                    <p className="font-semibold text-white">Offer archetype</p>
+                    <p>{offer.name} — ${offer.monthlyPrice}/mo, promo {offer.promoMonths} mo, device subsidy ${offer.deviceSubsidy}.</p>
+                  </div>
+                )
+              },
+              {
+                id: 'channels',
+                title: 'Channel mix',
+                info: {
+                  title: 'Channel mix',
+                  description: 'Default channel allocation to start your campaign design.'
+                },
+                body: (
+                  <ul className="space-y-1 text-sm">
+                    {Object.entries(defaultMix).map(([channelId, weight]) => (
+                      <li key={channelId}>
+                        {channels.find((ch) => ch.id === channelId)?.name ?? channelId}: {(weight * 100).toFixed(0)}%
+                      </li>
+                    ))}
+                  </ul>
+                )
+              },
+              {
+                id: 'why',
+                title: 'Why this works',
+                info: {
+                  title: 'Why this works',
+                  description: 'Bulletproof your case with the key qualitative reasons.'
+                },
+                body: (
+                  <ul className="list-disc space-y-1 pl-4 text-sm">
+                    <li>High digital responsiveness — {Math.round(recommended.micro.attractiveness * 100)} index.</li>
+                    <li>Offer bundling aligns with traits: {recommended.micro.traits.slice(0, 2).join(', ')}.</li>
+                    <li>Projected payback {typeof recommended.sim.paybackMonths === 'number' ? `${recommended.sim.paybackMonths} mo` : recommended.sim.paybackMonths}.</li>
+                  </ul>
+                )
               }
-            },
-            {
-              label: '12-mo GM',
-              value: `$${recommended.sim.gm12m.toLocaleString()}`,
-              info: {
-                title: '12-Month Incremental Gross Margin',
-                description: 'Gross margin over first 12 months after servicing costs and device amortization.',
-                primarySource: 'Synth Cohort Econ'
-              }
-            }
-          ]}
-          action={
-            <button
-              onClick={() => {
-                if (!selectedMicroIds.includes(recommended.micro.id)) {
-                  setSelectedMicro([...selectedMicroIds, recommended.micro.id]);
+            ]}
+            kpis={[
+              {
+                label: 'Payback (mo)',
+                value: typeof recommended.sim.paybackMonths === 'number' ? recommended.sim.paybackMonths : recommended.sim.paybackMonths,
+                info: {
+                  title: 'CAC Payback (months)',
+                  description: 'Months until fully-loaded CAC is covered by cumulative contribution.'
                 }
-                navigate('/campaign-designer');
-              }}
-              className="w-full rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-600"
-            >
-              Add to selection tray
-            </button>
-          }
-        />
-      ) : (
-        <div className="card border border-slate-800 p-4 text-sm text-slate-300">
-          Select cohorts to view targeting guidance.
+              },
+              {
+                label: '12-mo GM',
+                value: `$${recommended.sim.gm12m.toLocaleString()}`,
+                info: {
+                  title: '12-Month Incremental Gross Margin',
+                  description: 'Gross margin over the first 12 months after servicing costs and device amortization.'
+                }
+              }
+            ]}
+            action={
+              <button
+                onClick={() => {
+                  if (!selectedMicroIds.includes(recommended.micro.id)) {
+                    setSelectedMicro([...selectedMicroIds, recommended.micro.id]);
+                  }
+                  navigate('/campaign-designer');
+                }}
+                className="w-full rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-600"
+              >
+                Move to Campaign Designer
+              </button>
+            }
+          />
+        ) : (
+          <div className="card border border-slate-800 p-4 text-sm text-slate-300">
+            Select cohorts to view targeting guidance.
+          </div>
+        )}
+        <div className="col-span-3">
+          <SelectionTray
+            title="Micro-segments selected"
+            items={selectedMicroIds.map((id) => {
+              const entry = subsegments.find((sub) => sub.micro.id === id);
+              return {
+                id,
+                label: entry ? `${entry.segment.name} — ${entry.micro.name}` : id,
+                subtitle: entry ? `${(entry.micro.sizeShare * 100).toFixed(1)}% of cohort` : ''
+              };
+            })}
+            metrics={trayMetrics}
+            ctaLabel="Move to Campaign Designer"
+            onCta={() => navigate('/campaign-designer')}
+            disabled={!selectedMicroIds.length}
+          />
         </div>
-      )}
-      <div className="col-span-3">
-        <SelectionTray
-          title="Sub-segments selected"
-          items={selectedMicroIds.map((id) => {
-            const entry = subsegments.find((sub) => sub.micro.id === id);
-            return {
-              id,
-              label: entry ? `${entry.segment.name} — ${entry.micro.name}` : id,
-              subtitle: entry ? `${(entry.micro.sizeShare * 100).toFixed(1)}% of cohort` : ''
-            };
-          })}
-          metrics={trayMetrics}
-          ctaLabel="Send to Campaign Designer"
-          onCta={() => navigate('/campaign-designer')}
-          disabled={!selectedMicroIds.length}
-        />
       </div>
     </div>
   );

--- a/src/app/routes/SegmentStudio.tsx
+++ b/src/app/routes/SegmentStudio.tsx
@@ -56,6 +56,7 @@ const SegmentStudio: React.FC = () => {
 
   const sortedSubsegments = [...subsegments].sort((a, b) => b.micro.attractiveness - a.micro.attractiveness);
   const topThreeIds = sortedSubsegments.slice(0, 3).map((s) => s.micro.id);
+  const nextBest = sortedSubsegments[1];
 
   const toggleSelection = (microId: string, checked: boolean) => {
     const current = new Set(selectedMicroIds);
@@ -160,7 +161,7 @@ const SegmentStudio: React.FC = () => {
             </div>
           </div>
         </aside>
-        <section className="flex flex-col gap-4">
+        <section className="flex min-w-0 flex-col gap-4">
           {recommended ? (
             <div className="card border border-emerald-500/30 bg-emerald-500/10 p-5">
               <div className="flex items-start justify-between gap-4">
@@ -169,16 +170,23 @@ const SegmentStudio: React.FC = () => {
                   <h2 className="text-xl font-semibold text-white">
                     Lead with {offer.name} for {recommended.segment.name} — {recommended.micro.name}
                   </h2>
-                  <p className="mt-2 text-sm text-emerald-100">
+                  <p className="mt-2 max-w-3xl text-sm text-emerald-100">
                     Focus on a digital-first mix and lean on bundled value to win share quickly.
                   </p>
                 </div>
                 <InfoPopover title="Recommended play" description="Use this starter move and fine-tune as you learn more." />
               </div>
               <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-emerald-100">
-                <li>Top-ranked attractiveness ({Math.round(recommended.micro.attractiveness * 100)} index) with strong conversion potential.</li>
-                <li>Offer match: {offer.name} aligns with traits {recommended.micro.traits.slice(0, 2).join(' & ')}.</li>
-                <li>Payback expectation: {typeof recommended.sim.paybackMonths === 'number' ? `${recommended.sim.paybackMonths} months` : recommended.sim.paybackMonths} with ${recommended.sim.gm12m.toLocaleString()} GM.</li>
+                <li>
+                  Highest attractiveness index ({Math.round(recommended.micro.attractiveness * 100)}) versus {nextBest ? `${Math.round(nextBest.micro.attractiveness * 100)} for the runner-up, translating to ${(recommended.sim.conversionRate * 100).toFixed(1)}% conversion` : `${(recommended.sim.conversionRate * 100).toFixed(1)}% conversion`}.
+                </li>
+                <li>
+                  Sized opportunity: ~{Math.round(recommended.micro.sizeShare * recommended.segment.size).toLocaleString()} reachable households with{' '}
+                  {Math.round((defaultMix['ch-search'] + defaultMix['ch-social'] + defaultMix['ch-email']) * 100)}% digital coverage and projected net adds of {Math.round(recommended.sim.netAdds).toLocaleString()}.
+                </li>
+                <li>
+                  Economics check: payback {typeof recommended.sim.paybackMonths === 'number' ? `${recommended.sim.paybackMonths} mo` : recommended.sim.paybackMonths}, {recommended.sim.marginPct}% margin, and {recommended.sim.breakdown.promoCost ? `$${recommended.sim.breakdown.promoCost.toLocaleString()}` : '$0'} promo spend delivering {recommended.sim.gm12m ? `$${recommended.sim.gm12m.toLocaleString()}` : '$0'} gross margin.
+                </li>
               </ul>
             </div>
           ) : null}
@@ -220,9 +228,14 @@ const SegmentStudio: React.FC = () => {
                 body: (
                   <div className="space-y-2 text-sm">
                     <p className="font-semibold text-white">Goal</p>
-                    <p>Drive high-value conversions among {recommended.segment.name} using {offer.name} with a heavier digital mix.</p>
+                    <p className="break-words">
+                      Drive high-value conversions among {recommended.segment.name} using {offer.name}, targeting {(recommended.sim.conversionRate * 100).toFixed(1)}% conversion and{' '}
+                      {Math.round(recommended.sim.netAdds).toLocaleString()} net adds within guardrails.
+                    </p>
                     <p className="font-semibold text-white">Offer archetype</p>
-                    <p>{offer.name} — ${offer.monthlyPrice}/mo, promo {offer.promoMonths} mo, device subsidy ${offer.deviceSubsidy}.</p>
+                    <p className="break-words">
+                      {offer.name} — ${offer.monthlyPrice}/mo, promo {offer.promoMonths} mo, device subsidy ${offer.deviceSubsidy}. Recommended mix keeps CAC at ${recommended.sim.breakdown.cac.toLocaleString()} with {recommended.sim.marginPct}% margin.
+                    </p>
                   </div>
                 )
               },
@@ -252,9 +265,15 @@ const SegmentStudio: React.FC = () => {
                 },
                 body: (
                   <ul className="list-disc space-y-1 pl-4 text-sm">
-                    <li>High digital responsiveness — {Math.round(recommended.micro.attractiveness * 100)} index.</li>
-                    <li>Offer bundling aligns with traits: {recommended.micro.traits.slice(0, 2).join(', ')}.</li>
-                    <li>Projected payback {typeof recommended.sim.paybackMonths === 'number' ? `${recommended.sim.paybackMonths} mo` : recommended.sim.paybackMonths}.</li>
+                    <li>
+                      Digital responsiveness index {Math.round(recommended.micro.attractiveness * 100)} enables {Math.round((defaultMix['ch-search'] + defaultMix['ch-social'] + defaultMix['ch-email']) * 100)}% reach through efficient channels.
+                    </li>
+                    <li>
+                      Offer bundling aligns with traits {recommended.micro.traits.slice(0, 3).join(', ')} and defends versus {recommended.segment.traits.slice(0, 1).join(', ') || 'competitors'}.
+                    </li>
+                    <li>
+                      Financial guardrails hold: payback {typeof recommended.sim.paybackMonths === 'number' ? `${recommended.sim.paybackMonths} mo` : recommended.sim.paybackMonths}, 12-mo GM {recommended.sim.gm12m ? `$${recommended.sim.gm12m.toLocaleString()}` : '$0'}, margin {recommended.sim.marginPct}%.
+                    </li>
                   </ul>
                 )
               }

--- a/src/app/routes/SegmentStudio.tsx
+++ b/src/app/routes/SegmentStudio.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import RightRail from '../../components/RightRail';
+import SelectionTray from '../../components/SelectionTray';
+import SubsegmentTile from '../../components/SubsegmentTile';
+import { simulateAudience } from '../../sim/tinySim';
+import { useGlobalStore } from '../../store/global';
+
+const defaultMix = {
+  'ch-search': 0.32,
+  'ch-social': 0.24,
+  'ch-email': 0.16,
+  'ch-retail': 0.18,
+  'ch-field': 0.1
+};
+
+const SegmentStudio: React.FC = () => {
+  const navigate = useNavigate();
+  const cartSegmentIds = useGlobalStore((s) => s.cartSegmentIds);
+  const segments = useGlobalStore((s) => s.segments);
+  const microSegmentsByParent = useGlobalStore((s) => s.microSegmentsByParent);
+  const assumptions = useGlobalStore((s) => s.assumptions);
+  const offers = useGlobalStore((s) => s.offers);
+  const channels = useGlobalStore((s) => s.channels);
+  const selectedMicroIds = useGlobalStore((s) => s.selectedMicroIds);
+  const setSelectedMicro = useGlobalStore((s) => s.setSelectedMicro);
+
+  const offer = offers[1] ?? offers[0];
+
+  const sourceCohorts = cartSegmentIds.map((id) => segments.find((s) => s.id === id)).filter(Boolean);
+
+  const subsegments = React.useMemo(() => {
+    return sourceCohorts.flatMap((segment) => {
+      const micros = microSegmentsByParent[segment!.id] ?? [];
+      const total = micros.reduce((sum, micro) => sum + micro.sizeShare, 0) || 1;
+      return micros.map((micro, index) => {
+        const normalized = { ...micro, sizeShare: micro.sizeShare / total };
+        const sim = simulateAudience({
+          micro: normalized,
+          segmentSize: segment!.size,
+          offer,
+          channelMix: defaultMix,
+          assumptions,
+          channels
+        });
+        return {
+          micro: normalized,
+          segment,
+          sim,
+          rank: index + 1
+        };
+      });
+    });
+  }, [assumptions, channels, microSegmentsByParent, offer, sourceCohorts]);
+
+  const sortedSubsegments = [...subsegments].sort((a, b) => b.micro.attractiveness - a.micro.attractiveness);
+  const topThreeIds = sortedSubsegments.slice(0, 3).map((s) => s.micro.id);
+
+  const toggleSelection = (microId: string, checked: boolean) => {
+    const current = new Set(selectedMicroIds);
+    if (checked) {
+      current.add(microId);
+    } else {
+      current.delete(microId);
+    }
+    setSelectedMicro(Array.from(current));
+  };
+
+  const trayMetrics = React.useMemo(() => {
+    if (!selectedMicroIds.length) {
+      return [
+        { label: 'Combined size', value: '0%' },
+        { label: 'Blended payback', value: '–' },
+        { label: '12-mo GM', value: '–' }
+      ];
+    }
+    let totalShare = 0;
+    let totalPayback = 0;
+    let totalGm = 0;
+    selectedMicroIds.forEach((id) => {
+      const item = subsegments.find((sub) => sub.micro.id === id);
+      if (!item) return;
+      totalShare += item.micro.sizeShare * item.segment.size;
+      totalGm += item.sim.gm12m * item.segment.size;
+      totalPayback += (typeof item.sim.paybackMonths === 'number' ? item.sim.paybackMonths : 24) * item.segment.size;
+    });
+    const denominator = selectedMicroIds.reduce((sum, id) => {
+      const item = subsegments.find((sub) => sub.micro.id === id);
+      if (!item) return sum;
+      return sum + item.segment.size;
+    }, 0);
+    return [
+      { label: 'Combined size', value: `${((totalShare / Math.max(1, denominator)) * 100).toFixed(1)}%` },
+      { label: 'Blended payback', value: denominator ? `${Math.round(totalPayback / denominator)} mo` : '–' },
+      { label: '12-mo GM', value: denominator ? `$${Math.round(totalGm / denominator).toLocaleString()}` : '–' }
+    ];
+  }, [selectedMicroIds, subsegments]);
+
+  const recommended = sortedSubsegments[0];
+
+  return (
+    <div className="grid grid-cols-[240px_1fr_320px] gap-6">
+      <aside className="flex flex-col gap-4">
+        <div className="card border border-slate-800 p-4">
+          <p className="text-xs uppercase tracking-wide text-emerald-400">How to use</p>
+          <p className="mt-2 text-sm text-slate-300">
+            This view breaks your selected cohort(s) into sub-segments and recommends how to target each. Pick the ones you want to take into the campaign.
+          </p>
+        </div>
+        <div className="card border border-slate-800 p-4">
+          <h3 className="text-sm font-semibold text-white">Source cohorts</h3>
+          <div className="mt-2 space-y-2">
+            {sourceCohorts.map((segment) => (
+              <div key={segment!.id} className="rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-xs text-slate-300">
+                <p className="text-sm font-semibold text-white">{segment!.name}</p>
+                <p>{segment!.size.toLocaleString()} households</p>
+                <p>Primary traits: {segment!.traits.slice(0, 2).join(', ')}</p>
+              </div>
+            ))}
+            {!sourceCohorts.length ? <p className="text-xs text-slate-500">No cohorts yet—head back to Market Radar.</p> : null}
+          </div>
+          <p className="mt-3 text-[11px] uppercase tracking-wide text-emerald-400">Primary data sources (est.): Synth Cohort Econ / Segment Fabric</p>
+        </div>
+      </aside>
+      <section className="flex flex-col gap-4">
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {sortedSubsegments.map((entry) => (
+            <SubsegmentTile
+              key={entry.micro.id}
+              name={`${entry.segment.name} — ${entry.micro.name}`}
+              rank={entry.rank}
+              sizeShare={entry.micro.sizeShare}
+              payback={entry.sim.paybackMonths}
+              gm12={entry.sim.gm12m}
+              traits={entry.micro.traits}
+              rationale={`Attractiveness ${(entry.micro.attractiveness * 100).toFixed(0)} • Conversion ${(entry.sim.conversionRate * 100).toFixed(1)}%`}
+              selected={selectedMicroIds.includes(entry.micro.id)}
+              highlight={topThreeIds.includes(entry.micro.id)}
+              onSelect={(checked) => toggleSelection(entry.micro.id, checked)}
+            />
+          ))}
+        </div>
+      </section>
+      {recommended ? (
+        <RightRail
+          title="Targeting strategy"
+          subtitle="AI-assisted recommendation"
+          sections={[
+            {
+              id: 'strategy',
+              title: 'Recommended play',
+              defaultOpen: true,
+              body: (
+                <div className="space-y-2 text-sm">
+                  <p className="font-semibold text-white">Goal</p>
+                  <p>Drive high-value conversions among {recommended.segment.name} using {offer.name} with a heavier digital mix.</p>
+                  <p className="font-semibold text-white">Offer archetype</p>
+                  <p>{offer.name} — ${offer.monthlyPrice}/mo, promo {offer.promoMonths} mo, device subsidy ${offer.deviceSubsidy}.</p>
+                </div>
+              )
+            },
+            {
+              id: 'channels',
+              title: 'Channel mix',
+              body: (
+                <ul className="space-y-1 text-sm">
+                  {Object.entries(defaultMix).map(([channelId, weight]) => (
+                    <li key={channelId}>
+                      {channels.find((ch) => ch.id === channelId)?.name ?? channelId}: {(weight * 100).toFixed(0)}%
+                    </li>
+                  ))}
+                </ul>
+              )
+            },
+            {
+              id: 'why',
+              title: 'Why this works',
+              body: (
+                <ul className="list-disc space-y-1 pl-4 text-sm">
+                  <li>High digital responsiveness — {Math.round(recommended.micro.attractiveness * 100)} index.</li>
+                  <li>Offer bundling aligns with traits: {recommended.micro.traits.slice(0, 2).join(', ')}.</li>
+                  <li>Projected payback {typeof recommended.sim.paybackMonths === 'number' ? `${recommended.sim.paybackMonths} mo` : recommended.sim.paybackMonths}.</li>
+                </ul>
+              )
+            }
+          ]}
+          kpis={[
+            {
+              label: 'Payback (mo)',
+              value: typeof recommended.sim.paybackMonths === 'number' ? recommended.sim.paybackMonths : recommended.sim.paybackMonths,
+              info: {
+                title: 'CAC Payback (months)',
+                description: 'Months until fully-loaded CAC is covered by cumulative contribution.',
+                primarySource: 'Synth Cohort Econ'
+              }
+            },
+            {
+              label: '12-mo GM',
+              value: `$${recommended.sim.gm12m.toLocaleString()}`,
+              info: {
+                title: '12-Month Incremental Gross Margin',
+                description: 'Gross margin over first 12 months after servicing costs and device amortization.',
+                primarySource: 'Synth Cohort Econ'
+              }
+            }
+          ]}
+          action={
+            <button
+              onClick={() => {
+                if (!selectedMicroIds.includes(recommended.micro.id)) {
+                  setSelectedMicro([...selectedMicroIds, recommended.micro.id]);
+                }
+                navigate('/campaign-designer');
+              }}
+              className="w-full rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-600"
+            >
+              Add to selection tray
+            </button>
+          }
+        />
+      ) : (
+        <div className="card border border-slate-800 p-4 text-sm text-slate-300">
+          Select cohorts to view targeting guidance.
+        </div>
+      )}
+      <div className="col-span-3">
+        <SelectionTray
+          title="Sub-segments selected"
+          items={selectedMicroIds.map((id) => {
+            const entry = subsegments.find((sub) => sub.micro.id === id);
+            return {
+              id,
+              label: entry ? `${entry.segment.name} — ${entry.micro.name}` : id,
+              subtitle: entry ? `${(entry.micro.sizeShare * 100).toFixed(1)}% of cohort` : ''
+            };
+          })}
+          metrics={trayMetrics}
+          ctaLabel="Send to Campaign Designer"
+          onCta={() => navigate('/campaign-designer')}
+          disabled={!selectedMicroIds.length}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SegmentStudio;

--- a/src/components/BubbleChart.tsx
+++ b/src/components/BubbleChart.tsx
@@ -1,4 +1,5 @@
 import { ResponsiveContainer, Scatter, ScatterChart, Tooltip, XAxis, YAxis, ZAxis, CartesianGrid } from 'recharts';
+import InfoPopover from './InfoPopover';
 import { Segment } from '../store/global';
 
 export type BubblePoint = {
@@ -31,6 +32,7 @@ const BubbleChart = ({ segments, data, onSelect }: Props) => {
           <h3 className="text-lg font-semibold text-white">Market Opportunity View</h3>
           <p className="text-xs text-slate-400">Bubble size = projected net adds • X = opportunity score • Y = cohort size</p>
         </div>
+        <InfoPopover title="Opportunity bubbles" description="Click a bubble to inspect a cohort and shortlist it." />
       </div>
       <ResponsiveContainer width="100%" height="100%">
         <ScatterChart margin={{ top: 30, right: 30, left: 0, bottom: 20 }}>

--- a/src/components/BubbleChart.tsx
+++ b/src/components/BubbleChart.tsx
@@ -1,0 +1,82 @@
+import { ResponsiveContainer, Scatter, ScatterChart, Tooltip, XAxis, YAxis, ZAxis, CartesianGrid } from 'recharts';
+import { Segment } from '../store/global';
+
+export type BubblePoint = {
+  id: string;
+  opportunity: number;
+  size: number;
+  netAdds: number;
+  category: string;
+};
+
+type Props = {
+  segments: Segment[];
+  data: BubblePoint[];
+  onSelect: (id: string) => void;
+};
+
+const colors = ['#34d399', '#22d3ee', '#facc15', '#fb7185', '#818cf8', '#38bdf8'];
+
+const renderNode = (props: any) => {
+  const { cx, cy, payload } = props;
+  const radius = Math.max(8, Math.sqrt(payload.netAdds) / 5);
+  return <circle cx={cx} cy={cy} r={radius} fill={payload.fill} fillOpacity={0.8} stroke="#0f172a" strokeWidth={1.5} />;
+};
+
+const BubbleChart = ({ segments, data, onSelect }: Props) => {
+  return (
+    <div className="card h-80 w-full border border-slate-800 p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-white">Market Opportunity View</h3>
+          <p className="text-xs text-slate-400">Bubble size = projected net adds • X = opportunity score • Y = cohort size</p>
+        </div>
+      </div>
+      <ResponsiveContainer width="100%" height="100%">
+        <ScatterChart margin={{ top: 30, right: 30, left: 0, bottom: 20 }}>
+          <CartesianGrid stroke="#1f2937" strokeDasharray="3 3" />
+          <XAxis type="number" dataKey="opportunity" name="Opportunity" domain={[0, 100]} tick={{ fill: '#94a3b8', fontSize: 12 }}
+            label={{ value: 'Opportunity score', position: 'insideBottom', offset: -10, fill: '#94a3b8' }}
+          />
+          <YAxis
+            type="number"
+            dataKey="size"
+            name="Cohort size"
+            tickFormatter={(val) => `${(val / 1000).toFixed(0)}k`}
+            tick={{ fill: '#94a3b8', fontSize: 12 }}
+            label={{ value: 'Cohort size', angle: -90, position: 'insideLeft', fill: '#94a3b8' }}
+          />
+          <ZAxis dataKey="netAdds" range={[60, 400]} name="Net Adds" />
+          <Tooltip
+            cursor={{ stroke: '#22d3ee', strokeWidth: 1 }}
+            content={({ active, payload }) => {
+              if (!active || !payload?.length) return null;
+              const point = payload[0].payload as BubblePoint;
+              const segment = segments.find((s) => s.id === point.id);
+              return (
+                <div className="card border border-emerald-500/20 p-3 text-xs">
+                  <p className="text-sm font-semibold text-white">{segment?.name ?? 'Segment'}</p>
+                  <p className="text-slate-300">Opportunity score: {point.opportunity.toFixed(1)}</p>
+                  <p className="text-slate-300">Projected net adds: {Math.round(point.netAdds).toLocaleString()}</p>
+                  <p className="text-slate-300">Cohort size: {segment?.size.toLocaleString()}</p>
+                </div>
+              );
+            }}
+          />
+          <Scatter
+            name="Cohorts"
+            data={data.map((point, idx) => ({ ...point, fill: colors[idx % colors.length] }))}
+            shape={renderNode}
+            onClick={(node) => {
+              if (node && (node as any).id) {
+                onSelect((node as any).id as string);
+              }
+            }}
+          />
+        </ScatterChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default BubbleChart;

--- a/src/components/Info.tsx
+++ b/src/components/Info.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Info as InfoIcon } from 'lucide-react';
+
+type InfoProps = {
+  title: string;
+  body: React.ReactNode;
+  side?: 'top' | 'bottom' | 'left' | 'right';
+};
+
+const Info: React.FC<InfoProps> = ({ title, body, side = 'top' }) => {
+  const [open, setOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    const onClick = (event: MouseEvent) => {
+      if (triggerRef.current && !triggerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', onClick);
+    return () => document.removeEventListener('click', onClick);
+  }, []);
+
+  const positionClass =
+    side === 'top'
+      ? '-top-3 left-1/2 -translate-x-1/2 -translate-y-full'
+      : side === 'bottom'
+        ? 'top-full left-1/2 -translate-x-1/2 mt-2'
+        : side === 'left'
+          ? 'right-full mr-3 top-1/2 -translate-y-1/2'
+          : 'left-full ml-3 top-1/2 -translate-y-1/2';
+
+  return (
+    <div className="relative inline-flex">
+      <button
+        ref={triggerRef}
+        onClick={(event) => {
+          event.stopPropagation();
+          setOpen((prev) => !prev);
+        }}
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-emerald-500/60 bg-emerald-500/10 text-emerald-200 transition hover:bg-emerald-500/20"
+        aria-label={`What is ${title}?`}
+      >
+        <InfoIcon className="h-3.5 w-3.5" />
+      </button>
+      {open ? (
+        <div
+          role="dialog"
+          className={`card absolute z-50 w-72 border border-emerald-500/30 bg-slate-950/95 p-4 text-sm shadow-emerald-500/10 ${positionClass}`}
+        >
+          <p className="text-xs font-semibold uppercase tracking-wide text-emerald-300">{title}</p>
+          <div className="mt-2 space-y-2 text-[13px] leading-relaxed text-slate-200">{body}</div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default Info;
+

--- a/src/components/InfoPopover.tsx
+++ b/src/components/InfoPopover.tsx
@@ -4,7 +4,7 @@ import { Info } from 'lucide-react';
 export type InfoProps = {
   title: string;
   description: string;
-  primarySource: string;
+  primarySource?: string;
   placement?: 'top' | 'bottom' | 'left' | 'right';
 };
 
@@ -53,9 +53,11 @@ const InfoPopover: React.FC<InfoProps> = ({ title, description, primarySource, p
         >
           <p className="text-sm font-semibold text-emerald-300">{title}</p>
           <p className="mt-2 leading-relaxed text-slate-200">{description}</p>
-          <p className="mt-2 text-[11px] uppercase tracking-wide text-emerald-400">
-            Primary data source (est.): {primarySource}
-          </p>
+          {primarySource ? (
+            <p className="mt-2 text-[11px] uppercase tracking-wide text-emerald-400">
+              Primary data source (est.): {primarySource}
+            </p>
+          ) : null}
         </div>
       )}
     </div>

--- a/src/components/InfoPopover.tsx
+++ b/src/components/InfoPopover.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Info } from 'lucide-react';
+
+export type InfoProps = {
+  title: string;
+  description: string;
+  primarySource: string;
+  placement?: 'top' | 'bottom' | 'left' | 'right';
+};
+
+const InfoPopover: React.FC<InfoProps> = ({ title, description, primarySource, placement = 'top' }) => {
+  const [open, setOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+
+  const toggle = () => setOpen((prev) => !prev);
+
+  React.useEffect(() => {
+    const onClick = (event: MouseEvent) => {
+      if (triggerRef.current && !triggerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', onClick);
+    return () => document.removeEventListener('click', onClick);
+  }, []);
+
+  const positionClass =
+    placement === 'top'
+      ? '-translate-y-full -top-3 left-1/2 -translate-x-1/2'
+      : placement === 'bottom'
+        ? 'top-full left-1/2 -translate-x-1/2 mt-2'
+        : placement === 'left'
+          ? 'right-full mr-2 top-1/2 -translate-y-1/2'
+          : 'left-full ml-2 top-1/2 -translate-y-1/2';
+
+  return (
+    <div className="relative inline-flex">
+      <button
+        ref={triggerRef}
+        onClick={(event) => {
+          event.stopPropagation();
+          toggle();
+        }}
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-emerald-500/60 bg-emerald-500/10 text-emerald-300 transition hover:bg-emerald-500/20"
+        aria-label={`More info about ${title}`}
+      >
+        <Info className="h-3.5 w-3.5" />
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          className={`card absolute z-40 w-64 border border-emerald-500/20 p-3 text-xs text-slate-200 shadow-emerald-500/10 ${positionClass}`}
+        >
+          <p className="text-sm font-semibold text-emerald-300">{title}</p>
+          <p className="mt-2 leading-relaxed text-slate-200">{description}</p>
+          <p className="mt-2 text-[11px] uppercase tracking-wide text-emerald-400">
+            Primary data source (est.): {primarySource}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InfoPopover;

--- a/src/components/KpiTile.tsx
+++ b/src/components/KpiTile.tsx
@@ -1,0 +1,34 @@
+import InfoPopover, { InfoProps } from './InfoPopover';
+
+export type KpiTileProps = {
+  label: string;
+  value: string | number;
+  suffix?: string;
+  info?: InfoProps;
+  onClick?: () => void;
+};
+
+const KpiTile = ({ label, value, suffix, info, onClick }: KpiTileProps) => {
+  return (
+    <button
+      type={onClick ? 'button' : undefined}
+      onClick={onClick}
+      className={`card group flex w-full flex-col items-start gap-2 border border-slate-800 p-4 text-left transition hover:border-emerald-500/40 hover:shadow-emerald-500/20 ${
+        onClick ? 'cursor-pointer' : 'cursor-default'
+      }`}
+    >
+      <div className="flex w-full items-center justify-between">
+        <span className="text-xs uppercase tracking-wide text-slate-400">{label}</span>
+        {info ? <InfoPopover {...info} placement="left" /> : null}
+      </div>
+      <div className="flex items-baseline gap-1">
+        <span className="text-2xl font-semibold text-white">
+          {typeof value === 'number' ? value.toLocaleString(undefined, { maximumFractionDigits: 1 }) : value}
+        </span>
+        {suffix ? <span className="text-sm text-slate-400">{suffix}</span> : null}
+      </div>
+    </button>
+  );
+};
+
+export default KpiTile;

--- a/src/components/KpiTile.tsx
+++ b/src/components/KpiTile.tsx
@@ -4,11 +4,12 @@ export type KpiTileProps = {
   label: string;
   value: string | number;
   suffix?: string;
+  sublabel?: string;
   info?: InfoProps;
   onClick?: () => void;
 };
 
-const KpiTile = ({ label, value, suffix, info, onClick }: KpiTileProps) => {
+const KpiTile = ({ label, value, suffix, sublabel, info, onClick }: KpiTileProps) => {
   return (
     <button
       type={onClick ? 'button' : undefined}
@@ -27,6 +28,7 @@ const KpiTile = ({ label, value, suffix, info, onClick }: KpiTileProps) => {
         </span>
         {suffix ? <span className="text-sm text-slate-400">{suffix}</span> : null}
       </div>
+      {sublabel ? <p className="text-xs text-slate-400">{sublabel}</p> : null}
     </button>
   );
 };

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import InfoPopover from './InfoPopover';
 
 export type GeoNode = {
   id: string;
@@ -45,14 +46,17 @@ const MapView: React.FC<Props> = ({ root, onSelectRegion }) => {
           <h3 className="text-lg font-semibold text-white">Competitive Map</h3>
           <p className="text-xs text-slate-400">Double-click to drill into {path.length === 0 ? 'DMA' : path.length === 1 ? 'ZIP3' : 'details'} level.</p>
         </div>
-        {path.length > 0 ? (
-          <button
-            onClick={goBack}
-            className="rounded-full border border-emerald-500/40 px-3 py-1 text-xs text-emerald-200 hover:bg-emerald-500/10"
-          >
-            ← Back to {path.length === 1 ? 'States' : 'DMAs'}
-          </button>
-        ) : null}
+        <div className="flex items-center gap-2">
+          <InfoPopover title="Competitive map" description="Use the map to spot geographies where payback improves fastest." />
+          {path.length > 0 ? (
+            <button
+              onClick={goBack}
+              className="rounded-full border border-emerald-500/40 px-3 py-1 text-xs text-emerald-200 hover:bg-emerald-500/10"
+            >
+              ← Back to {path.length === 1 ? 'States' : 'DMAs'}
+            </button>
+          ) : null}
+        </div>
       </div>
       <div className="grid flex-1 grid-cols-3 gap-2">
         {nodes.map((node) => (
@@ -75,9 +79,6 @@ const MapView: React.FC<Props> = ({ root, onSelectRegion }) => {
           </button>
         ))}
       </div>
-      <p className="text-[11px] uppercase tracking-wide text-emerald-400">
-        Primary data source (est.): GeoSynth Coverage / Competitive Intelligence
-      </p>
     </div>
   );
 };

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+export type GeoNode = {
+  id: string;
+  name: string;
+  value: number;
+  children?: GeoNode[];
+  meta?: Record<string, string>;
+};
+
+type Props = {
+  root: GeoNode[];
+  onSelectRegion: (path: GeoNode[]) => void;
+};
+
+const MapView: React.FC<Props> = ({ root, onSelectRegion }) => {
+  const [path, setPath] = React.useState<GeoNode[]>([]);
+  const nodes = path.length === 0 ? root : path[path.length - 1].children ?? [];
+
+  const handleDoubleClick = (node: GeoNode) => {
+    if (node.children && node.children.length) {
+      const nextPath = [...path, node];
+      setPath(nextPath);
+      onSelectRegion(nextPath);
+    } else {
+      const nextPath = [...path, node];
+      onSelectRegion(nextPath);
+    }
+  };
+
+  const goBack = () => {
+    const next = path.slice(0, -1);
+    setPath(next);
+    if (next.length) {
+      onSelectRegion(next);
+    }
+  };
+
+  const levelLabel = path.length === 0 ? 'State' : path.length === 1 ? 'DMA' : 'ZIP3';
+
+  return (
+    <div className="card flex h-80 flex-col gap-3 border border-slate-800 p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-white">Competitive Map</h3>
+          <p className="text-xs text-slate-400">Double-click to drill into {path.length === 0 ? 'DMA' : path.length === 1 ? 'ZIP3' : 'details'} level.</p>
+        </div>
+        {path.length > 0 ? (
+          <button
+            onClick={goBack}
+            className="rounded-full border border-emerald-500/40 px-3 py-1 text-xs text-emerald-200 hover:bg-emerald-500/10"
+          >
+            ← Back to {path.length === 1 ? 'States' : 'DMAs'}
+          </button>
+        ) : null}
+      </div>
+      <div className="grid flex-1 grid-cols-3 gap-2">
+        {nodes.map((node) => (
+          <button
+            key={node.id}
+            onDoubleClick={() => handleDoubleClick(node)}
+            onClick={() => onSelectRegion([...path, node])}
+            className="group relative flex flex-col items-start justify-between overflow-hidden rounded-xl border border-slate-800 bg-slate-900/70 p-3 text-left transition hover:border-emerald-500/50"
+          >
+            <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/10 via-transparent to-slate-900/40 opacity-0 transition group-hover:opacity-100" />
+            <div className="relative flex w-full items-center justify-between">
+              <span className="text-sm font-semibold text-white">{node.name}</span>
+              <span className="text-xs text-emerald-300">{levelLabel} score</span>
+            </div>
+            <div className="relative mt-6 w-full">
+              <div className="h-2 w-full rounded-full bg-slate-800" />
+              <div className="-mt-2 h-2 rounded-full bg-emerald-500" style={{ width: `${Math.min(100, Math.max(0, node.value))}%` }} />
+            </div>
+            <p className="relative mt-2 text-xs text-slate-300">Payback improvement potential: {(node.value / 10).toFixed(1)} mo</p>
+          </button>
+        ))}
+      </div>
+      <p className="text-[11px] uppercase tracking-wide text-emerald-400">
+        Primary data source (est.): GeoSynth Coverage / Competitive Intelligence
+      </p>
+    </div>
+  );
+};
+
+export default MapView;

--- a/src/components/MiniBadge.tsx
+++ b/src/components/MiniBadge.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+type MiniBadgeProps = {
+  tone?: 'emerald' | 'slate' | 'amber';
+  children: React.ReactNode;
+};
+
+const toneMap: Record<NonNullable<MiniBadgeProps['tone']>, string> = {
+  emerald: 'bg-emerald-500/15 text-emerald-200 border-emerald-500/40',
+  slate: 'bg-slate-800/80 text-slate-200 border-slate-600/60',
+  amber: 'bg-amber-500/15 text-amber-100 border-amber-400/40'
+};
+
+const MiniBadge: React.FC<MiniBadgeProps> = ({ tone = 'slate', children }) => {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide ${toneMap[tone]}`}
+    >
+      {children}
+    </span>
+  );
+};
+
+export default MiniBadge;
+

--- a/src/components/PillToggle.tsx
+++ b/src/components/PillToggle.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+export type PillToggleOption<T extends string> = {
+  id: T;
+  label: string;
+};
+
+type Props<T extends string> = {
+  options: PillToggleOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+};
+
+const PillToggle = <T extends string>({ options, value, onChange }: Props<T>) => {
+  return (
+    <div className="inline-flex items-center rounded-full border border-emerald-500/30 bg-slate-900 p-1 text-xs">
+      {options.map((option) => {
+        const active = option.id === value;
+        return (
+          <button
+            key={option.id}
+            onClick={() => onChange(option.id)}
+            className={`rounded-full px-3 py-1 font-medium transition ${
+              active ? 'bg-emerald-500 text-slate-950' : 'text-slate-300 hover:bg-emerald-500/10'
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default PillToggle;

--- a/src/components/RightRail.tsx
+++ b/src/components/RightRail.tsx
@@ -31,9 +31,12 @@ const RightRail: React.FC<Props> = ({ title, subtitle, kpis = [], sections, acti
 
   return (
     <aside className="card flex h-full flex-col gap-4 border border-slate-800 p-4">
-      <header>
-        <h3 className="text-xl font-semibold text-white">{title}</h3>
-        {subtitle ? <p className="text-xs text-slate-400">{subtitle}</p> : null}
+      <header className="flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-xl font-semibold text-white">{title}</h3>
+          {subtitle ? <p className="text-xs text-slate-400">{subtitle}</p> : null}
+        </div>
+        <InfoPopover title={title} description="Use this panel to unpack the selected cohort and recommended moves." />
       </header>
       {kpis.length ? (
         <div className="grid grid-cols-2 gap-3">
@@ -54,12 +57,15 @@ const RightRail: React.FC<Props> = ({ title, subtitle, kpis = [], sections, acti
         {sections.map((section) => {
           const isOpen = openSections[section.id];
           return (
-            <div key={section.id} className="border border-slate-800/80 rounded-xl bg-slate-900/70">
+            <div key={section.id} className="rounded-xl border border-slate-800/80 bg-slate-900/70">
               <button
                 className="flex w-full items-center justify-between px-3 py-2 text-left text-sm font-semibold text-white"
                 onClick={() => toggleSection(section.id)}
               >
-                <span>{section.title}</span>
+                <span className="inline-flex items-center gap-2">
+                  {section.title}
+                  {section.info ? <InfoPopover {...section.info} placement="left" /> : null}
+                </span>
                 <span className="text-xs text-emerald-300">{isOpen ? 'Hide' : 'Show'}</span>
               </button>
               {isOpen ? <div className="space-y-3 border-t border-slate-800 px-3 py-3 text-sm text-slate-300">{section.body}</div> : null}
@@ -68,9 +74,6 @@ const RightRail: React.FC<Props> = ({ title, subtitle, kpis = [], sections, acti
         })}
       </div>
       {action ? <div className="mt-auto">{action}</div> : null}
-      <p className="text-[11px] uppercase tracking-wide text-emerald-400">
-        Primary data sources (est.): Synth Cohort Econ / Recon Signals / Competitive Pulse
-      </p>
     </aside>
   );
 };

--- a/src/components/RightRail.tsx
+++ b/src/components/RightRail.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import InfoPopover, { InfoProps } from './InfoPopover';
+
+export type RightRailSection = {
+  id: string;
+  title: string;
+  body: React.ReactNode;
+  info?: InfoProps;
+  defaultOpen?: boolean;
+};
+
+type Props = {
+  title: string;
+  subtitle?: string;
+  kpis?: { label: string; value: string | number; info?: InfoProps }[];
+  sections: RightRailSection[];
+  action?: React.ReactNode;
+};
+
+const RightRail: React.FC<Props> = ({ title, subtitle, kpis = [], sections, action }) => {
+  const [openSections, setOpenSections] = React.useState<Record<string, boolean>>(() => {
+    return sections.reduce((acc, section) => {
+      acc[section.id] = section.defaultOpen ?? true;
+      return acc;
+    }, {} as Record<string, boolean>);
+  });
+
+  const toggleSection = (id: string) => {
+    setOpenSections((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  return (
+    <aside className="card flex h-full flex-col gap-4 border border-slate-800 p-4">
+      <header>
+        <h3 className="text-xl font-semibold text-white">{title}</h3>
+        {subtitle ? <p className="text-xs text-slate-400">{subtitle}</p> : null}
+      </header>
+      {kpis.length ? (
+        <div className="grid grid-cols-2 gap-3">
+          {kpis.map((kpi) => (
+            <div key={kpi.label} className="card border border-slate-800/70 bg-slate-900/70 p-3">
+              <div className="flex items-center justify-between text-xs text-slate-400">
+                <span>{kpi.label}</span>
+                {kpi.info ? <InfoPopover {...kpi.info} placement="left" /> : null}
+              </div>
+              <p className="mt-1 text-lg font-semibold text-white">
+                {typeof kpi.value === 'number' ? kpi.value.toLocaleString() : kpi.value}
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+      <div className="flex flex-col gap-3">
+        {sections.map((section) => {
+          const isOpen = openSections[section.id];
+          return (
+            <div key={section.id} className="border border-slate-800/80 rounded-xl bg-slate-900/70">
+              <button
+                className="flex w-full items-center justify-between px-3 py-2 text-left text-sm font-semibold text-white"
+                onClick={() => toggleSection(section.id)}
+              >
+                <span>{section.title}</span>
+                <span className="text-xs text-emerald-300">{isOpen ? 'Hide' : 'Show'}</span>
+              </button>
+              {isOpen ? <div className="space-y-3 border-t border-slate-800 px-3 py-3 text-sm text-slate-300">{section.body}</div> : null}
+            </div>
+          );
+        })}
+      </div>
+      {action ? <div className="mt-auto">{action}</div> : null}
+      <p className="text-[11px] uppercase tracking-wide text-emerald-400">
+        Primary data sources (est.): Synth Cohort Econ / Recon Signals / Competitive Pulse
+      </p>
+    </aside>
+  );
+};
+
+export default RightRail;

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Info from './Info';
+
+type SectionProps = {
+  title: string;
+  info?: {
+    title: string;
+    body: React.ReactNode;
+  };
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+const Section: React.FC<SectionProps> = ({ title, info, actions, children }) => {
+  return (
+    <section className="space-y-4">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-300">{title}</h2>
+            {info ? <Info title={info.title} body={info.body} /> : null}
+          </div>
+        </div>
+        {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+      </header>
+      <div className="space-y-4 rounded-2xl border border-slate-800/80 bg-slate-900/60 p-5 shadow-inner shadow-slate-950/40">
+        {children}
+      </div>
+    </section>
+  );
+};
+
+export default Section;
+

--- a/src/components/SegmentTile.tsx
+++ b/src/components/SegmentTile.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, Pin, Send, ShoppingCart } from 'lucide-react';
+import { CheckCircle2, Pin, Send } from 'lucide-react';
 import InfoPopover from './InfoPopover';
 
 export type SegmentTileProps = {
@@ -31,9 +31,15 @@ const SegmentTile = ({
   return (
     <article className={`card flex flex-col gap-4 border border-slate-800 p-5 transition hover:border-emerald-500/40`}>
       <header className="flex items-start justify-between gap-3">
-        <div>
-          <h3 className="text-lg font-semibold text-white">{name}</h3>
-          <p className="text-xs text-slate-400">{size.toLocaleString()} households</p>
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-lg font-semibold text-white">{name}</h3>
+            <InfoPopover title="Cohort tile" description="Review the cohort summary, shortlist it, or send it forward." />
+          </div>
+          <div className="flex items-center gap-2 text-xs text-slate-400">
+            <span>{size.toLocaleString()} households</span>
+            <InfoPopover title="Cohort size" description="Shows the estimated audience count for this cohort." />
+          </div>
         </div>
         <div className="flex items-center gap-2 text-xs">
           <button
@@ -61,7 +67,6 @@ const SegmentTile = ({
             <InfoPopover
               title="CAC Payback (months)"
               description="Months until fully-loaded CAC is covered by cumulative contribution."
-              primarySource="Synth Cohort Econ"
             />
           </div>
           <p className="mt-1 text-xl font-semibold text-white">{typeof payback === 'number' ? `${payback}` : payback}</p>
@@ -72,32 +77,35 @@ const SegmentTile = ({
             <InfoPopover
               title="12-Month Incremental Gross Margin"
               description="Gross margin over first 12 months after servicing costs and device amortization."
-              primarySource="Synth Cohort Econ"
             />
           </div>
           <p className="mt-1 text-xl font-semibold text-white">${gm12.toLocaleString()}</p>
         </div>
       </div>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         {traits.slice(0, 4).map((trait) => (
           <span key={trait} className="info-chip">
             {trait}
           </span>
         ))}
+        <InfoPopover title="Trait chips" description="Quick cues that explain why this cohort behaves the way it does." />
       </div>
-      <p className="text-sm text-slate-300">{rationale}</p>
-      <footer className="flex flex-wrap items-center gap-2 text-sm">
+      <p className="flex items-start gap-2 text-sm text-slate-300">
+        <InfoPopover title="Why it matters" description="One-line rationale to help you remember the opportunity." />
+        <span>{rationale}</span>
+      </p>
+      <footer className="flex flex-wrap items-center gap-3 text-sm">
         <button
           onClick={onAddToCart}
-          className="inline-flex items-center gap-2 rounded-full bg-emerald-500 px-3 py-1 font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-600"
+          className="inline-flex items-center gap-2 rounded-full bg-emerald-500 px-4 py-1.5 font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-600"
         >
-          <ShoppingCart className="h-4 w-4" /> Add to Cart
+          Shortlist cohort
         </button>
         <button
           onClick={onSendToStudio}
-          className="inline-flex items-center gap-2 rounded-full border border-emerald-500/40 bg-slate-900 px-3 py-1 text-emerald-200 transition hover:bg-emerald-500/10"
+          className="inline-flex items-center gap-2 rounded-full border border-emerald-500/40 bg-slate-900 px-4 py-1.5 text-emerald-200 transition hover:bg-emerald-500/10"
         >
-          <Send className="h-4 w-4" /> Send to Studio
+          <Send className="h-4 w-4" /> Advance now
         </button>
         {selected ? (
           <span className="ml-auto inline-flex items-center gap-2 text-emerald-300">

--- a/src/components/SegmentTile.tsx
+++ b/src/components/SegmentTile.tsx
@@ -1,0 +1,112 @@
+import { CheckCircle2, Pin, Send, ShoppingCart } from 'lucide-react';
+import InfoPopover from './InfoPopover';
+
+export type SegmentTileProps = {
+  name: string;
+  size: number;
+  payback: number | string;
+  gm12: number;
+  traits: string[];
+  rationale: string;
+  selected: boolean;
+  onSelect: (checked: boolean) => void;
+  onAddToCart?: () => void;
+  onSendToStudio?: () => void;
+  onPin?: () => void;
+};
+
+const SegmentTile = ({
+  name,
+  size,
+  payback,
+  gm12,
+  traits,
+  rationale,
+  selected,
+  onSelect,
+  onAddToCart,
+  onSendToStudio,
+  onPin
+}: SegmentTileProps) => {
+  return (
+    <article className={`card flex flex-col gap-4 border border-slate-800 p-5 transition hover:border-emerald-500/40`}>
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-white">{name}</h3>
+          <p className="text-xs text-slate-400">{size.toLocaleString()} households</p>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <button
+            onClick={onPin}
+            className="rounded-full border border-emerald-500/30 bg-emerald-500/10 p-1 text-emerald-300 hover:bg-emerald-500/20"
+            aria-label={`Pin ${name}`}
+          >
+            <Pin className="h-4 w-4" />
+          </button>
+          <label className="flex items-center gap-1 text-emerald-300">
+            <input
+              type="checkbox"
+              checked={selected}
+              onChange={(event) => onSelect(event.target.checked)}
+              className="h-4 w-4 rounded border border-emerald-500/40 bg-slate-900 text-emerald-500"
+            />
+            Select
+          </label>
+        </div>
+      </header>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="card border border-slate-800/60 bg-slate-900/70 p-3">
+          <div className="flex items-center justify-between text-xs text-slate-400">
+            <span>CAC Payback</span>
+            <InfoPopover
+              title="CAC Payback (months)"
+              description="Months until fully-loaded CAC is covered by cumulative contribution."
+              primarySource="Synth Cohort Econ"
+            />
+          </div>
+          <p className="mt-1 text-xl font-semibold text-white">{typeof payback === 'number' ? `${payback}` : payback}</p>
+        </div>
+        <div className="card border border-slate-800/60 bg-slate-900/70 p-3">
+          <div className="flex items-center justify-between text-xs text-slate-400">
+            <span>12-mo Incremental GM</span>
+            <InfoPopover
+              title="12-Month Incremental Gross Margin"
+              description="Gross margin over first 12 months after servicing costs and device amortization."
+              primarySource="Synth Cohort Econ"
+            />
+          </div>
+          <p className="mt-1 text-xl font-semibold text-white">${gm12.toLocaleString()}</p>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {traits.slice(0, 4).map((trait) => (
+          <span key={trait} className="info-chip">
+            {trait}
+          </span>
+        ))}
+      </div>
+      <p className="text-sm text-slate-300">{rationale}</p>
+      <footer className="flex flex-wrap items-center gap-2 text-sm">
+        <button
+          onClick={onAddToCart}
+          className="inline-flex items-center gap-2 rounded-full bg-emerald-500 px-3 py-1 font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-600"
+        >
+          <ShoppingCart className="h-4 w-4" /> Add to Cart
+        </button>
+        <button
+          onClick={onSendToStudio}
+          className="inline-flex items-center gap-2 rounded-full border border-emerald-500/40 bg-slate-900 px-3 py-1 text-emerald-200 transition hover:bg-emerald-500/10"
+        >
+          <Send className="h-4 w-4" /> Send to Studio
+        </button>
+        {selected ? (
+          <span className="ml-auto inline-flex items-center gap-2 text-emerald-300">
+            <CheckCircle2 className="h-4 w-4" /> In Cart
+          </span>
+        ) : null}
+      </footer>
+    </article>
+  );
+};
+
+export default SegmentTile;

--- a/src/components/SelectionTray.tsx
+++ b/src/components/SelectionTray.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+export type SelectionTrayProps = {
+  title: string;
+  items: { id: string; label: string; subtitle?: string }[];
+  metrics: { label: string; value: string | number }[];
+  ctaLabel: string;
+  onCta: () => void;
+  disabled?: boolean;
+};
+
+const SelectionTray: React.FC<SelectionTrayProps> = ({ title, items, metrics, ctaLabel, onCta, disabled }) => {
+  return (
+    <div className="sticky bottom-4 z-20 mt-8 rounded-2xl border border-emerald-500/40 bg-slate-900/95 p-4 shadow-lg shadow-emerald-500/10">
+      <div className="flex flex-wrap items-center gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-emerald-400">{title}</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {items.length ? (
+              items.map((item) => (
+                <span key={item.id} className="info-chip">
+                  <span className="font-semibold text-emerald-200">{item.label}</span>
+                  {item.subtitle ? <span className="text-slate-300"> • {item.subtitle}</span> : null}
+                </span>
+              ))
+            ) : (
+              <span className="text-sm text-slate-400">No selections yet.</span>
+            )}
+          </div>
+        </div>
+        <div className="ml-auto flex flex-wrap items-center gap-6">
+          {metrics.map((metric) => (
+            <div key={metric.label} className="text-sm text-slate-300">
+              <span className="text-xs uppercase tracking-wide text-slate-500">{metric.label}</span>
+              <p className="text-lg font-semibold text-white">{metric.value}</p>
+            </div>
+          ))}
+          <button
+            onClick={onCta}
+            disabled={disabled}
+            className="rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {ctaLabel}
+          </button>
+        </div>
+      </div>
+      <p className="mt-2 text-[11px] uppercase tracking-wide text-emerald-400">
+        Primary data source (est.): Synth Cohort Econ / Planner Workspace
+      </p>
+    </div>
+  );
+};
+
+export default SelectionTray;

--- a/src/components/SelectionTray.tsx
+++ b/src/components/SelectionTray.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import InfoPopover from './InfoPopover';
 
 export type SelectionTrayProps = {
   title: string;
@@ -44,9 +45,19 @@ const SelectionTray: React.FC<SelectionTrayProps> = ({ title, items, metrics, ct
           </button>
         </div>
       </div>
-      <p className="mt-2 text-[11px] uppercase tracking-wide text-emerald-400">
-        Primary data source (est.): Synth Cohort Econ / Planner Workspace
-      </p>
+      {metrics.length ? (
+        <div className="mt-3 flex flex-wrap gap-4 text-xs text-slate-400">
+          {metrics.map((metric) => (
+            <div key={`info-${metric.label}`} className="flex items-center gap-2">
+              <InfoPopover
+                title={metric.label}
+                description={`This metric summarizes ${metric.label.toLowerCase()} across the current selection.`}
+              />
+              <span>Use to communicate progress for {metric.label.toLowerCase()}.</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/components/SubsegmentTile.tsx
+++ b/src/components/SubsegmentTile.tsx
@@ -40,9 +40,15 @@ const SubsegmentTile = ({
         </span>
       ) : null}
       <header className="flex items-start justify-between gap-3">
-        <div>
-          <h3 className="text-lg font-semibold text-white">{name}</h3>
-          <p className="text-xs text-slate-400">{(sizeShare * 100).toFixed(1)}% of cohort</p>
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-lg font-semibold text-white">{name}</h3>
+            <InfoPopover title="Micro-segment tile" description="Review this sub-audience and decide if it belongs in your plan." />
+          </div>
+          <div className="flex items-center gap-2 text-xs text-slate-400">
+            <span>{(sizeShare * 100).toFixed(1)}% of cohort</span>
+            <InfoPopover title="Size share" description="Portion of the parent cohort represented by this micro-segment." />
+          </div>
         </div>
         <label className="flex items-center gap-1 text-emerald-300">
           <input
@@ -58,34 +64,30 @@ const SubsegmentTile = ({
         <div className="card border border-slate-800/60 bg-slate-900/70 p-3">
           <div className="flex items-center justify-between text-xs text-slate-400">
             <span>CAC Payback</span>
-            <InfoPopover
-              title="CAC Payback (months)"
-              description="Months until fully-loaded CAC is covered by cumulative contribution."
-              primarySource="Synth Cohort Econ"
-            />
+            <InfoPopover title="CAC Payback (months)" description="Months until fully-loaded CAC is covered by cumulative contribution." />
           </div>
           <p className="mt-1 text-xl font-semibold text-white">{typeof payback === 'number' ? `${payback}` : payback}</p>
         </div>
         <div className="card border border-slate-800/60 bg-slate-900/70 p-3">
           <div className="flex items-center justify-between text-xs text-slate-400">
             <span>12-mo Incremental GM</span>
-            <InfoPopover
-              title="12-Month Incremental Gross Margin"
-              description="Gross margin over first 12 months after servicing costs and device amortization."
-              primarySource="Synth Cohort Econ"
-            />
+            <InfoPopover title="12-Month Incremental Gross Margin" description="Gross margin over first 12 months after servicing costs and device amortization." />
           </div>
           <p className="mt-1 text-xl font-semibold text-white">${gm12.toLocaleString()}</p>
         </div>
       </div>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         {traits.slice(0, 3).map((trait) => (
           <span key={trait} className="info-chip">
             {trait}
           </span>
         ))}
+        <InfoPopover title="Trait highlights" description="Use these cues to align messaging and offer levers." />
       </div>
-      <p className="text-sm text-slate-300">{rationale}</p>
+      <p className="flex items-start gap-2 text-sm text-slate-300">
+        <InfoPopover title="Rationale" description="Quick reminder of why this micro-segment matters." />
+        <span>{rationale}</span>
+      </p>
       {highlight ? (
         <p className="text-xs uppercase tracking-wide text-emerald-300">
           Why highlighted: optimal mix of economics, reach, and signal richness.

--- a/src/components/SubsegmentTile.tsx
+++ b/src/components/SubsegmentTile.tsx
@@ -1,0 +1,101 @@
+import { CheckSquare, Sparkles } from 'lucide-react';
+import InfoPopover from './InfoPopover';
+
+export type SubsegmentTileProps = {
+  name: string;
+  rank: number;
+  sizeShare: number;
+  payback: number | string;
+  gm12: number;
+  traits: string[];
+  rationale: string;
+  selected: boolean;
+  highlight?: boolean;
+  onSelect: (checked: boolean) => void;
+};
+
+const SubsegmentTile = ({
+  name,
+  rank,
+  sizeShare,
+  payback,
+  gm12,
+  traits,
+  rationale,
+  selected,
+  highlight,
+  onSelect
+}: SubsegmentTileProps) => {
+  return (
+    <article
+      className={`card relative flex flex-col gap-4 border p-5 transition ${
+        highlight
+          ? 'border-emerald-500/60 shadow-emerald-500/20 before:absolute before:left-0 before:top-0 before:h-full before:w-1 before:bg-emerald-500'
+          : 'border-slate-800 hover:border-emerald-500/40'
+      }`}
+    >
+      {highlight ? (
+        <span className="absolute right-4 top-4 inline-flex items-center gap-1 rounded-full bg-emerald-500/20 px-2 py-1 text-xs text-emerald-200">
+          <Sparkles className="h-3.5 w-3.5" /> Top pick #{rank}
+        </span>
+      ) : null}
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-white">{name}</h3>
+          <p className="text-xs text-slate-400">{(sizeShare * 100).toFixed(1)}% of cohort</p>
+        </div>
+        <label className="flex items-center gap-1 text-emerald-300">
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={(event) => onSelect(event.target.checked)}
+            className="h-4 w-4 rounded border border-emerald-500/40 bg-slate-900 text-emerald-500"
+          />
+          Select for campaign
+        </label>
+      </header>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="card border border-slate-800/60 bg-slate-900/70 p-3">
+          <div className="flex items-center justify-between text-xs text-slate-400">
+            <span>CAC Payback</span>
+            <InfoPopover
+              title="CAC Payback (months)"
+              description="Months until fully-loaded CAC is covered by cumulative contribution."
+              primarySource="Synth Cohort Econ"
+            />
+          </div>
+          <p className="mt-1 text-xl font-semibold text-white">{typeof payback === 'number' ? `${payback}` : payback}</p>
+        </div>
+        <div className="card border border-slate-800/60 bg-slate-900/70 p-3">
+          <div className="flex items-center justify-between text-xs text-slate-400">
+            <span>12-mo Incremental GM</span>
+            <InfoPopover
+              title="12-Month Incremental Gross Margin"
+              description="Gross margin over first 12 months after servicing costs and device amortization."
+              primarySource="Synth Cohort Econ"
+            />
+          </div>
+          <p className="mt-1 text-xl font-semibold text-white">${gm12.toLocaleString()}</p>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {traits.slice(0, 3).map((trait) => (
+          <span key={trait} className="info-chip">
+            {trait}
+          </span>
+        ))}
+      </div>
+      <p className="text-sm text-slate-300">{rationale}</p>
+      {highlight ? (
+        <p className="text-xs uppercase tracking-wide text-emerald-300">
+          Why highlighted: optimal mix of economics, reach, and signal richness.
+        </p>
+      ) : null}
+      <div className="flex items-center gap-2 text-xs text-emerald-300">
+        <CheckSquare className="h-4 w-4" /> AI recommendation active
+      </div>
+    </article>
+  );
+};
+
+export default SubsegmentTile;

--- a/src/components/SubsegmentTile.tsx
+++ b/src/components/SubsegmentTile.tsx
@@ -28,7 +28,7 @@ const SubsegmentTile = ({
 }: SubsegmentTileProps) => {
   return (
     <article
-      className={`card relative flex flex-col gap-4 border p-5 transition ${
+      className={`card relative flex min-w-0 flex-col gap-4 border p-5 transition ${
         highlight
           ? 'border-emerald-500/60 shadow-emerald-500/20 before:absolute before:left-0 before:top-0 before:h-full before:w-1 before:bg-emerald-500'
           : 'border-slate-800 hover:border-emerald-500/40'
@@ -42,10 +42,10 @@ const SubsegmentTile = ({
       <header className="flex items-start justify-between gap-3">
         <div className="space-y-1">
           <div className="flex items-center gap-2">
-            <h3 className="text-lg font-semibold text-white">{name}</h3>
+            <h3 className="min-w-0 break-words text-lg font-semibold text-white">{name}</h3>
             <InfoPopover title="Micro-segment tile" description="Review this sub-audience and decide if it belongs in your plan." />
           </div>
-          <div className="flex items-center gap-2 text-xs text-slate-400">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
             <span>{(sizeShare * 100).toFixed(1)}% of cohort</span>
             <InfoPopover title="Size share" description="Portion of the parent cohort represented by this micro-segment." />
           </div>
@@ -86,7 +86,7 @@ const SubsegmentTile = ({
       </div>
       <p className="flex items-start gap-2 text-sm text-slate-300">
         <InfoPopover title="Rationale" description="Quick reminder of why this micro-segment matters." />
-        <span>{rationale}</span>
+        <span className="break-words">{rationale}</span>
       </p>
       {highlight ? (
         <p className="text-xs uppercase tracking-wide text-emerald-300">

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+export type ToastVariant = 'default' | 'success' | 'warning';
+
+type Toast = {
+  id: string;
+  title?: string;
+  description: string;
+  variant?: ToastVariant;
+};
+
+type ToastContextValue = {
+  pushToast: (toast: Omit<Toast, 'id'>) => void;
+};
+
+const ToastContext = React.createContext<ToastContextValue | undefined>(undefined);
+
+const createId = () => Math.random().toString(36).slice(2, 9);
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [toasts, setToasts] = React.useState<Toast[]>([]);
+
+  const pushToast = React.useCallback((toast: Omit<Toast, 'id'>) => {
+    const id = createId();
+    setToasts((prev) => [...prev, { ...toast, id }]);
+    window.setTimeout(() => {
+      setToasts((prev) => prev.filter((item) => item.id !== id));
+    }, 3200);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ pushToast }}>
+      {children}
+      <div className="pointer-events-none fixed bottom-6 right-6 z-[80] flex max-w-sm flex-col gap-3">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`pointer-events-auto overflow-hidden rounded-xl border px-4 py-3 shadow-lg shadow-slate-900/60 transition ${
+              toast.variant === 'success'
+                ? 'border-emerald-500/60 bg-emerald-500/15 text-emerald-100'
+                : toast.variant === 'warning'
+                  ? 'border-amber-400/60 bg-amber-500/15 text-amber-100'
+                  : 'border-slate-700 bg-slate-900/90 text-slate-100'
+            }`}
+          >
+            {toast.title ? <p className="text-sm font-semibold">{toast.title}</p> : null}
+            <p className="text-sm leading-relaxed">{toast.description}</p>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const ctx = React.useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx;
+};
+

--- a/src/components/TrendChip.tsx
+++ b/src/components/TrendChip.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export type TrendChipProps = {
+  value: number;
+  suffix?: string;
+};
+
+const TrendChip: React.FC<TrendChipProps> = ({ value, suffix }) => {
+  const positive = value >= 0;
+  const tone = positive
+    ? 'border-emerald-500/60 bg-emerald-500/15 text-emerald-200'
+    : 'border-rose-500/60 bg-rose-500/15 text-rose-200';
+  const icon = positive ? '▲' : '▼';
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-semibold ${tone}`}>
+      <span className="text-[10px] leading-none">{icon}</span>
+      <span>
+        {positive ? '+' : ''}
+        {value.toLocaleString(undefined, { maximumFractionDigits: Math.abs(value) < 10 ? 2 : 0 })}
+        {suffix ?? ''}
+      </span>
+    </span>
+  );
+};
+
+export default TrendChip;
+

--- a/src/data/seeds.ts
+++ b/src/data/seeds.ts
@@ -1,0 +1,252 @@
+import { Assumptions, CampaignPlan, Channel, Competitor, MicroSegment, OfferArchetype, Segment } from '../store/global';
+
+export const assumptionsSeed: Assumptions = {
+  grossMarginRate: 0.55,
+  servicingCostPerSubMo: 12,
+  deviceSubsidyAmortMo: 12,
+  executionCost: 20
+};
+
+export const segmentsSeed: Segment[] = [
+  {
+    id: 'seg-value-seekers',
+    name: 'Value Seekers',
+    size: 520_000,
+    traits: ['Budget-conscious', 'Digital-first', 'Promo responsive'],
+    priceSensitivity: 0.8,
+    valueSensitivity: 0.7,
+    region: 'National',
+    notes: 'Looking to upgrade from prepaid to postpaid bundles.'
+  },
+  {
+    id: 'seg-premium-loyal',
+    name: 'Premium Network Loyalists',
+    size: 310_000,
+    traits: ['Coverage focused', 'High ARPU', 'Family lines'],
+    priceSensitivity: 0.3,
+    valueSensitivity: 0.9,
+    region: 'Urban',
+    notes: 'Care deeply about reliability and device perks.'
+  },
+  {
+    id: 'seg-rural-seniors',
+    name: 'Rural Seniors',
+    size: 190_000,
+    traits: ['Fixed income', 'Voice heavy', 'Caregiver influenced'],
+    priceSensitivity: 0.6,
+    valueSensitivity: 0.4,
+    region: 'Rural',
+    notes: 'Interested in simple plans with support.'
+  },
+  {
+    id: 'seg-urban-streamers',
+    name: 'Urban Streamers',
+    size: 470_000,
+    traits: ['5G enthusiasts', 'Video heavy', 'Bundle ready'],
+    priceSensitivity: 0.4,
+    valueSensitivity: 0.8,
+    region: 'Urban',
+    notes: 'Need fast network and streaming perks.'
+  },
+  {
+    id: 'seg-family-bundlers',
+    name: 'Family Bundlers',
+    size: 260_000,
+    traits: ['Multiple lines', 'Home broadband', 'Device upgrade'],
+    priceSensitivity: 0.5,
+    valueSensitivity: 0.7,
+    region: 'Suburban',
+    notes: 'Open to switching if bundle value is clear.'
+  },
+  {
+    id: 'seg-switch-prepaid',
+    name: 'Switch-Prone Prepaid',
+    size: 340_000,
+    traits: ['Prepaid to postpaid drift', 'Promo savvy', 'High churn'],
+    priceSensitivity: 0.9,
+    valueSensitivity: 0.5,
+    region: 'National',
+    notes: 'Respond to price locks and device subsidies.'
+  },
+  {
+    id: 'seg-smallbiz-byod',
+    name: 'Small Biz BYOD',
+    size: 120_000,
+    traits: ['Business owners', 'Need support', 'Device flexibility'],
+    priceSensitivity: 0.45,
+    valueSensitivity: 0.65,
+    region: 'National',
+    notes: 'Care about service uptime and discounts.'
+  }
+];
+
+export const competitorsSeed: Competitor[] = [
+  { id: 'comp-alpha', name: 'AlphaMobile', basePrice: 65, promoDepth: 15, coverageScore: 82, valueScore: 74 },
+  { id: 'comp-beta', name: 'BetaTel', basePrice: 60, promoDepth: 20, coverageScore: 76, valueScore: 69 },
+  { id: 'comp-cable', name: 'CableCoMobile', basePrice: 55, promoDepth: 25, coverageScore: 68, valueScore: 71 },
+  { id: 'comp-magenta', name: 'MagentaNet', basePrice: 70, promoDepth: 18, coverageScore: 88, valueScore: 80 }
+];
+
+export const offersSeed: OfferArchetype[] = [
+  {
+    id: 'offer-value-bundle',
+    name: 'Value Bundle',
+    monthlyPrice: 55,
+    promoMonths: 3,
+    promoValue: 15,
+    deviceSubsidy: 120,
+    bundleFlags: ['Mobile', 'Streaming']
+  },
+  {
+    id: 'offer-device-boost',
+    name: 'Device Boost',
+    monthlyPrice: 68,
+    promoMonths: 6,
+    promoValue: 20,
+    deviceSubsidy: 200,
+    bundleFlags: ['Mobile', 'Device']
+  },
+  {
+    id: 'offer-price-lock',
+    name: 'Price-Lock 12',
+    monthlyPrice: 62,
+    promoMonths: 12,
+    promoValue: 10,
+    deviceSubsidy: 150,
+    bundleFlags: ['Mobile']
+  },
+  {
+    id: 'offer-streamer-pack',
+    name: 'Streamer Pack',
+    monthlyPrice: 72,
+    promoMonths: 4,
+    promoValue: 25,
+    deviceSubsidy: 160,
+    bundleFlags: ['Mobile', 'Streaming', 'Broadband']
+  }
+];
+
+export const channelsSeed: Channel[] = [
+  { id: 'ch-search', name: 'Search', cac: 65, eff: 0.9 },
+  { id: 'ch-social', name: 'Social', cac: 85, eff: 0.85 },
+  { id: 'ch-retail', name: 'Retail', cac: 140, eff: 0.75 },
+  { id: 'ch-field', name: 'Field', cac: 180, eff: 0.6 },
+  { id: 'ch-email', name: 'Email', cac: 50, eff: 0.7 }
+];
+
+const microTemplate = (
+  parentId: string,
+  names: string[],
+  baseTraits: string[][],
+  attractiveness: number[]
+): MicroSegment[] =>
+  names.map((name, idx) => ({
+    id: `${parentId}-micro-${idx + 1}`,
+    parentSegmentId: parentId,
+    name,
+    sizeShare: 0.08 + idx * 0.04,
+    traits: baseTraits[idx],
+    attractiveness: attractiveness[idx]
+  }));
+
+export const microSegmentsSeed: Record<string, MicroSegment[]> = {
+  'seg-value-seekers': microTemplate(
+    'seg-value-seekers',
+    ['Promo Loyal Switchers', 'Device Upgraders', 'Bundle Curious Families', 'New Mover Deal Seekers', 'Cord Cutters', 'Budget Gamers'],
+    [
+      ['High churn', 'Respond to promo emails', 'Metro mix'],
+      ['Need financing', 'Flagship interest', 'Trade-in ready'],
+      ['Two-line households', 'Streaming heavy', 'Looking for savings'],
+      ['Recent movers', 'Prepaid history', 'Fiber newly available'],
+      ['OTT heavy', '5G curious', 'Social buzz'],
+      ['Mobile gaming', 'Price sensitive', 'Low loyalty']
+    ],
+    [0.68, 0.72, 0.65, 0.7, 0.74, 0.6]
+  ),
+  'seg-premium-loyal': microTemplate(
+    'seg-premium-loyal',
+    ['Network Purists', 'Experience Seekers', 'Business Travelers', 'Family Coverage Maximizers', 'Early Tech Adopters', 'Luxury Device Fans'],
+    [
+      ['Need best coverage', '5G priority', 'Low churn'],
+      ['Care about perks', 'High NPS', 'Refer friends'],
+      ['Travel internationally', 'Roaming pain', 'Wi-Fi calling'],
+      ['Multiple lines', 'Coverage sharing', 'Kids streaming'],
+      ['Test new tech', 'Device pre-orders', 'Influencer'],
+      ['High device spend', 'Premium accessories', 'Low promo need']
+    ],
+    [0.82, 0.78, 0.7, 0.69, 0.75, 0.68]
+  ),
+  'seg-rural-seniors': microTemplate(
+    'seg-rural-seniors',
+    ['Caregiver Coordinated', 'Assisted Living Residents', 'Value Phone Loyalists', 'Seasonal Travelers', 'Community Connectors', 'Health Monitoring Users'],
+    [
+      ['Family plan decisions', 'Need simplicity', 'Phone insurance'],
+      ['Facility Wi-Fi gaps', 'Support heavy', 'Care staff influence'],
+      ['Discount watchers', 'Coupon usage', 'Device financing'],
+      ['Snowbirds', 'Coverage anxiety', 'Service bundlers'],
+      ['Local events', 'Word-of-mouth', 'Trust us brand'],
+      ['Wearables interested', 'Remote monitoring', 'Care team engaged']
+    ],
+    [0.54, 0.52, 0.48, 0.5, 0.47, 0.56]
+  ),
+  'seg-urban-streamers': microTemplate(
+    'seg-urban-streamers',
+    ['Live Stream Creators', 'Smart Home Leaders', 'Gaming Marathoners', 'Culture Shapers', 'Bundle Hackers', 'Gig Economy Power Users'],
+    [
+      ['Need uplink speed', 'Social heavy', 'Night owl usage'],
+      ['Device ecosystem', 'Automation heavy', 'Wi-Fi 6'],
+      ['Latency sensitive', 'Esports watchers', '5G mmWave'],
+      ['Trend setters', 'Bundle share', 'High data'],
+      ['Stack promos', 'OTT aggregator', 'Family plan'],
+      ['On-the-go', 'Multiple sims', 'Portable hotspot']
+    ],
+    [0.79, 0.74, 0.77, 0.71, 0.76, 0.72]
+  ),
+  'seg-family-bundlers': microTemplate(
+    'seg-family-bundlers',
+    ['Dual Income Parents', 'Hybrid Workers', 'Connected Teens', 'Budget Maximizers', 'New Parents', 'Smart Home Families'],
+    [
+      ['Time starved', 'Need clarity', 'Bundle ready'],
+      ['Hotspot heavy', 'Needs reliability', 'Device support'],
+      ['Gaming + streaming', 'Multiple devices', 'Social heavy'],
+      ['Coupon fans', 'Referral ready', 'Finance savvy'],
+      ['New baby', 'Monitoring interest', 'Safety first'],
+      ['IoT usage', 'Security cams', 'Voice assistant']
+    ],
+    [0.71, 0.69, 0.73, 0.66, 0.64, 0.68]
+  ),
+  'seg-switch-prepaid': microTemplate(
+    'seg-switch-prepaid',
+    ['Promo Hoppers', 'Credit Rebuilders', 'Device Switch Seekers', 'Gig Workers', 'College Streamers', 'Multi-line Savers'],
+    [
+      ['Churn monthly', 'Follow deals', 'Social influence'],
+      ['Need credit help', 'Auto pay challenged', 'Cash heavy'],
+      ['Want premium device', 'Bring own phone', 'Need financing'],
+      ['Flexible hours', 'Hotspot heavy', 'On the go'],
+      ['Campus deals', 'Streaming watch', 'Group plan interest'],
+      ['Multiple prepaid lines', 'Family sharing', 'International calling']
+    ],
+    [0.67, 0.6, 0.7, 0.65, 0.68, 0.63]
+  ),
+  'seg-smallbiz-byod': microTemplate(
+    'seg-smallbiz-byod',
+    ['Retail Owners', 'Professional Services', 'Contractor Crews', 'Food Truck Ops', 'Healthcare Practices', 'Remote Teams'],
+    [
+      ['POS reliant', 'Need support', 'Weekend spikes'],
+      ['Client facing', 'Conference heavy', 'White-glove'],
+      ['Field workers', 'Rugged devices', 'Coverage first'],
+      ['Mobile office', 'Seasonal demand', 'Cash flow focus'],
+      ['HIPAA aware', 'Device security', 'Care messaging'],
+      ['Collaborative tools', 'Video meetings', 'Data pooling']
+    ],
+    [0.66, 0.64, 0.58, 0.6, 0.62, 0.65]
+  )
+};
+
+export const defaultCampaign: CampaignPlan = {
+  audienceIds: [],
+  offerByAudience: {},
+  channelMixByAudience: {},
+  budgetTotal: 250000,
+  guardrails: { cacCeiling: 150, paybackTarget: 8 }
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 antialiased;
+}
+
+.card {
+  @apply rounded-xl bg-slate-900/80 shadow-lg shadow-black/30 backdrop-blur;
+}
+
+.info-chip {
+  @apply inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -15,5 +15,5 @@ body {
 }
 
 .info-chip {
-  @apply inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300;
+  @apply inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300 break-words whitespace-normal;
 }

--- a/src/lib/intentParser.ts
+++ b/src/lib/intentParser.ts
@@ -1,0 +1,51 @@
+const regionRegex = /(national|urban|suburban|rural|midwest|west|south|northeast)/i;
+const sizeRegex = /(\d{2,3})k/gi;
+const priceRegex = /(price|pay)\s*(under|below|less than)\s*\$(\d{2,3})/i;
+
+export type IntentResult = {
+  filters: Record<string, unknown>;
+  summary: string;
+};
+
+export const parseIntent = (input: string): IntentResult => {
+  const filters: Record<string, unknown> = {};
+  let summary: string[] = [];
+
+  const regionMatch = input.match(regionRegex);
+  if (regionMatch) {
+    filters.region = regionMatch[0].toLowerCase();
+    summary.push(`Region → ${regionMatch[0]}`);
+  }
+
+  const sizes: number[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = sizeRegex.exec(input)) !== null) {
+    sizes.push(Number(match[1]) * 1000);
+  }
+  if (sizes.length) {
+    filters.minSize = Math.min(...sizes);
+    summary.push(`Min size ≥ ${Math.min(...sizes).toLocaleString()}`);
+  }
+
+  const priceMatch = input.match(priceRegex);
+  if (priceMatch) {
+    filters.priceCeiling = Number(priceMatch[3]);
+    summary.push(`Price ceiling $${priceMatch[3]}`);
+  }
+
+  if (/high\s+value/i.test(input)) {
+    filters.valueSensitivity = 'high';
+    summary.push('Value sensitivity high');
+  }
+
+  if (/switch(ers|ing)/i.test(input)) {
+    filters.switchLikelihood = 'elevated';
+    summary.push('Switch likelihood elevated');
+  }
+
+  if (summary.length === 0) {
+    summary.push('No automatic changes; try "urban cohorts over 200k size"');
+  }
+
+  return { filters, summary: summary.join(' • ') };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { useGlobalStore } from './store/global';
+import { AppStoreProvider } from './store/AppStore';
+import { ToastProvider } from './components/ToastProvider';
 
 const Root = () => {
   const hydrate = useGlobalStore((s) => s.hydrate);
@@ -13,9 +15,13 @@ const Root = () => {
   }, [hydrate]);
 
   return (
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <ToastProvider>
+      <AppStoreProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AppStoreProvider>
+    </ToastProvider>
   );
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,26 @@
+import './index.css';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import { useGlobalStore } from './store/global';
+
+const Root = () => {
+  const hydrate = useGlobalStore((s) => s.hydrate);
+
+  React.useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  return (
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Root />
+  </React.StrictMode>
+);

--- a/src/sim/tinySim.ts
+++ b/src/sim/tinySim.ts
@@ -1,0 +1,216 @@
+import { Assumptions, Channel, MicroSegment, OfferArchetype } from '../store/global';
+
+export type TakeRateInput = {
+  priceSensitivity: number;
+  valueSensitivity: number;
+  attractiveness: number;
+  offer: OfferArchetype;
+  channelEffect: number;
+};
+
+export const logistic = (x: number) => 1 / (1 + Math.exp(-x));
+
+export const takeRate = ({ priceSensitivity, valueSensitivity, attractiveness, offer, channelEffect }: TakeRateInput): number => {
+  const pricePressure = (offer.monthlyPrice - 60) / 25;
+  const valueBoost = (offer.promoValue / 20 + offer.deviceSubsidy / 250 + offer.bundleFlags.length * 0.15) * valueSensitivity;
+  const channelBoost = channelEffect * 0.8;
+  const baseline = 0.03 + attractiveness * 0.035;
+  const score = baseline + valueBoost + channelBoost - pricePressure * priceSensitivity;
+  return Math.min(0.25, Math.max(0.01, logistic(score * 2) - 0.35 + attractiveness * 0.05));
+};
+
+export const arpu = (offer: OfferArchetype): number => offer.monthlyPrice;
+
+export const channelWeightedCAC = (mix: Record<string, number>, channels: Channel[]): number => {
+  return channels.reduce((sum, channel) => sum + (mix[channel.id] ?? 0) * channel.cac, 0);
+};
+
+type FullyLoadedCACInput = {
+  mix: Record<string, number>;
+  offer: OfferArchetype;
+  assumptions: Assumptions;
+  channels: Channel[];
+};
+
+export const fullyLoadedCAC = ({ mix, offer, assumptions, channels }: FullyLoadedCACInput): number => {
+  const channelCac = channelWeightedCAC(mix, channels);
+  return channelCac + assumptions.executionCost + offer.deviceSubsidy * 0.4;
+};
+
+type ContributionInput = {
+  arpu: number;
+  assumptions: Assumptions;
+  offer: OfferArchetype;
+};
+
+export const monthlyContribution = ({ arpu, assumptions, offer }: ContributionInput, month: number): number => {
+  const grossMargin = arpu * assumptions.grossMarginRate;
+  const servicing = assumptions.servicingCostPerSubMo;
+  const subsidy = month <= assumptions.deviceSubsidyAmortMo ? offer.deviceSubsidy / assumptions.deviceSubsidyAmortMo : 0;
+  const promo = month <= offer.promoMonths ? offer.promoValue : 0;
+  return grossMargin - servicing - subsidy - promo / Math.max(1, offer.promoMonths || 1);
+};
+
+type PaybackInput = {
+  mix: Record<string, number>;
+  offer: OfferArchetype;
+  assumptions: Assumptions;
+  channels: Channel[];
+};
+
+export const paybackMonths = (input: PaybackInput & { arpu: number }): number | string => {
+  const cac = fullyLoadedCAC(input);
+  let cumulative = 0;
+  for (let month = 1; month <= 24; month += 1) {
+    cumulative += monthlyContribution({ arpu: input.arpu, assumptions: input.assumptions, offer: input.offer }, month);
+    if (cumulative >= cac) {
+      return month;
+    }
+  }
+  return '>24';
+};
+
+type Gm12Input = {
+  arpu: number;
+  assumptions: Assumptions;
+  offer: OfferArchetype;
+};
+
+export const gm12m = (input: Gm12Input): number => {
+  let total = 0;
+  for (let month = 1; month <= 12; month += 1) {
+    total += monthlyContribution(input, month);
+  }
+  return Math.round(total);
+};
+
+export const netAdds = (segmentSize: number, reach: number, rate: number): number => {
+  return Math.round(segmentSize * reach * rate);
+};
+
+export type SimResult = {
+  paybackMonths: number | string;
+  gm12m: number;
+  conversionRate: number;
+  netAdds: number;
+  marginPct: number;
+  breakdown: {
+    cac: number;
+    promoCost: number;
+    deviceSubsidy: number;
+    executionCost: number;
+  };
+  timeline: { month: number; cumulativeContribution: number }[];
+};
+
+export type AudienceSimInput = {
+  micro: MicroSegment;
+  segmentSize: number;
+  offer: OfferArchetype;
+  channelMix: Record<string, number>;
+  assumptions: Assumptions;
+  channels: Channel[];
+};
+
+export const reachFromMix = (mix: Record<string, number>, channels: Channel[]): number => {
+  const base = 0.25;
+  const digital = (mix['ch-search'] ?? 0) * 0.35 + (mix['ch-social'] ?? 0) * 0.25 + (mix['ch-email'] ?? 0) * 0.2;
+  const offline = (mix['ch-retail'] ?? 0) * 0.18 + (mix['ch-field'] ?? 0) * 0.15;
+  const efficiency = channels.reduce((sum, channel) => sum + (mix[channel.id] ?? 0) * channel.eff, 0);
+  return Math.min(0.85, base + digital + offline + efficiency * 0.2);
+};
+
+export const simulateAudience = ({ micro, segmentSize, offer, channelMix, assumptions, channels }: AudienceSimInput): SimResult => {
+  const arpuValue = arpu(offer);
+  const reach = reachFromMix(channelMix, channels);
+  const channelEffect = channels.reduce((sum, channel) => sum + (channelMix[channel.id] ?? 0) * channel.eff, 0);
+  const rate = takeRate({
+    priceSensitivity: 0.6,
+    valueSensitivity: 0.7,
+    attractiveness: micro.attractiveness,
+    offer,
+    channelEffect
+  });
+  const conversion = Math.min(0.35, rate * reach);
+  const net = netAdds(segmentSize * micro.sizeShare, reach, rate);
+  const cac = fullyLoadedCAC({ mix: channelMix, offer, assumptions, channels });
+  const payback = paybackMonths({ mix: channelMix, offer, assumptions, channels, arpu: arpuValue });
+  const gm12 = gm12m({ arpu: arpuValue, assumptions, offer });
+  const promoCost = offer.promoValue * Math.min(offer.promoMonths, 6);
+  const timeline: { month: number; cumulativeContribution: number }[] = [];
+  let cumulative = 0;
+  for (let month = 1; month <= 12; month += 1) {
+    cumulative += monthlyContribution({ arpu: arpuValue, assumptions, offer }, month);
+    timeline.push({ month, cumulativeContribution: Math.round(cumulative - cac) });
+  }
+
+  return {
+    paybackMonths: payback,
+    gm12m: gm12,
+    conversionRate: Number(conversion.toFixed(3)),
+    netAdds: net,
+    marginPct: Number(((gm12 / (arpuValue * 12)) * 100).toFixed(1)),
+    breakdown: {
+      cac: Math.round(cac),
+      promoCost,
+      deviceSubsidy: offer.deviceSubsidy,
+      executionCost: assumptions.executionCost
+    },
+    timeline
+  };
+};
+
+type CampaignSimInput = {
+  audiences: AudienceSimInput[];
+};
+
+export const simulateCampaign = ({ audiences }: CampaignSimInput): {
+  blended: SimResult;
+  byAudience: Record<string, SimResult>;
+} => {
+  const byAudience: Record<string, SimResult> = {};
+  let totalNetAdds = 0;
+  let weightedPayback = 0;
+  let totalGm = 0;
+  let totalSpend = 0;
+  let totalArpu = 0;
+  let totalConversion = 0;
+  const timelineAccumulator: number[] = [];
+  const timelineCounts: number[] = [];
+
+  audiences.forEach((aud) => {
+    const result = simulateAudience(aud);
+    byAudience[aud.micro.id] = result;
+    totalNetAdds += result.netAdds;
+    totalGm += result.gm12m * result.netAdds;
+    totalArpu += arpu(aud.offer) * 12 * result.netAdds;
+    totalConversion += result.conversionRate;
+    const paybackValue = typeof result.paybackMonths === 'number' ? result.paybackMonths : 26;
+    weightedPayback += paybackValue * result.netAdds;
+    totalSpend += result.breakdown.cac * result.netAdds;
+    result.timeline.forEach((point, index) => {
+      timelineAccumulator[index] = (timelineAccumulator[index] ?? 0) + point.cumulativeContribution;
+      timelineCounts[index] = (timelineCounts[index] ?? 0) + 1;
+    });
+  });
+
+  const blended: SimResult = {
+    paybackMonths: totalNetAdds ? Math.round(weightedPayback / totalNetAdds) : '>24',
+    gm12m: totalNetAdds ? Math.round(totalGm / totalNetAdds) : 0,
+    conversionRate: Number((totalConversion / Math.max(1, audiences.length)).toFixed(3)),
+    netAdds: totalNetAdds,
+    marginPct: totalArpu ? Number(((totalGm / totalArpu) * 100).toFixed(1)) : 0,
+    breakdown: {
+      cac: totalNetAdds ? Math.round(totalSpend / totalNetAdds) : 0,
+      promoCost: audiences.reduce((sum, aud) => sum + aud.offer.promoValue, 0),
+      deviceSubsidy: audiences.reduce((sum, aud) => sum + aud.offer.deviceSubsidy, 0),
+      executionCost: audiences.reduce((sum, aud) => sum + aud.assumptions.executionCost, 0)
+    },
+    timeline: timelineAccumulator.map((value, index) => ({
+      month: index + 1,
+      cumulativeContribution: Math.round(value / Math.max(1, timelineCounts[index]))
+    }))
+  };
+
+  return { blended, byAudience };
+};

--- a/src/store/AppStore.tsx
+++ b/src/store/AppStore.tsx
@@ -1,0 +1,628 @@
+import React from 'react';
+
+const makeId = () => Math.random().toString(36).slice(2, 10);
+
+export type ChannelKey = 'Search' | 'Social' | 'Email' | 'Retail' | 'Field';
+
+export type CohortRef = {
+  id: string;
+  name: string;
+  size: number;
+};
+
+export type Campaign = {
+  id: string;
+  name: string;
+  cohorts: CohortRef[];
+  status: 'Planned' | 'Running' | 'Paused' | 'Completed';
+  channels: Record<ChannelKey, number>;
+  offer: {
+    price: number;
+    promoMonths: number;
+    promoValue: number;
+    deviceSubsidy: number;
+  };
+  kpis: {
+    cvr: number;
+    arpuDelta: number;
+    paybackMo: number;
+    gm12: number;
+    netAdds: number;
+    npsDelta: number;
+  };
+  agent: 'Acquisition' | 'Upsell' | 'Retention' | 'Optimization';
+  createdAt: number;
+  lastUpdate: number;
+};
+
+export type TelemetryPoint = {
+  t: number;
+  cvr: number;
+  arpuDelta: number;
+  netAdds: number;
+  churnDelta: number;
+};
+
+export type Monitoring = {
+  streams: Record<string, TelemetryPoint[]>;
+};
+
+type AgentAction = {
+  id: string;
+  campaignId: string;
+  timestamp: number;
+  summary: string;
+  lift: number;
+  status: 'Applied' | 'Queued';
+  details?: string;
+};
+
+type LaunchPayload = {
+  name: string;
+  cohorts: CohortRef[];
+  channels: Record<ChannelKey, number>;
+  offer: Campaign['offer'];
+  agent: Campaign['agent'];
+  kpis?: Campaign['kpis'];
+};
+
+type AppStoreState = {
+  campaigns: Campaign[];
+  monitoring: Monitoring;
+  agentActions: Record<string, AgentAction[]>;
+  autoOptimize: Record<string, boolean>;
+};
+
+type AppStoreValue = {
+  campaigns: Campaign[];
+  monitoring: Monitoring;
+  agentActions: Record<string, AgentAction[]>;
+  autoOptimize: Record<string, boolean>;
+  launchCampaign: (payload: LaunchPayload) => Campaign;
+  updateCampaign: (id: string, patch: Partial<Campaign>) => void;
+  toggleStatus: (id: string) => void;
+  tuneCampaign: (
+    id: string,
+    patch: {
+      channels?: Partial<Record<ChannelKey, number>>;
+      offer?: Partial<Campaign['offer']>;
+    }
+  ) => Campaign | undefined;
+  setAutoOptimize: (id: string, value: boolean) => void;
+  logAction: (campaignId: string, action: Omit<AgentAction, 'id' | 'campaignId' | 'timestamp'>) => void;
+  scoreImpact: (
+    channels: Record<ChannelKey, number>,
+    offer: Campaign['offer']
+  ) => Pick<Campaign['kpis'], 'cvr' | 'arpuDelta' | 'paybackMo' | 'gm12' | 'netAdds' | 'npsDelta'>;
+  estimateImpact: (
+    campaign: Campaign,
+    deltas: {
+      channels?: Partial<Record<ChannelKey, number>>;
+      offer?: Partial<Campaign['offer']>;
+    }
+  ) => {
+    next: Campaign['kpis'];
+    delta: {
+      cvr: number;
+      arpuDelta: number;
+      gm12: number;
+      netAdds: number;
+      paybackMo: number;
+      npsDelta: number;
+    };
+  };
+};
+
+const BASE_METRICS = {
+  cvr: 3.4,
+  arpuDelta: 6.8,
+  gm12: 920_000,
+  netAdds: 3800,
+  paybackMo: 6.4,
+  npsDelta: 5.6
+};
+
+const BASE_OFFER = {
+  price: 75,
+  promoMonths: 3,
+  promoValue: 120,
+  deviceSubsidy: 180
+};
+
+const CHANNEL_WEIGHTS: Record<ChannelKey, {
+  cvr: number;
+  arpu: number;
+  gm12: number;
+  netAdds: number;
+  payback: number;
+  nps: number;
+}> = {
+  Search: { cvr: 1.15, arpu: 0.4, gm12: 65_000, netAdds: 520, payback: -0.35, nps: 0.25 },
+  Social: { cvr: 0.95, arpu: 0.25, gm12: 58_000, netAdds: 470, payback: -0.28, nps: 0.18 },
+  Email: { cvr: 0.45, arpu: 0.55, gm12: 34_000, netAdds: 300, payback: -0.12, nps: 0.22 },
+  Retail: { cvr: 0.25, arpu: 1.2, gm12: 72_000, netAdds: 240, payback: 0.28, nps: 0.46 },
+  Field: { cvr: 0.2, arpu: 1.45, gm12: 68_000, netAdds: 210, payback: 0.36, nps: 0.4 }
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const normaliseChannels = (channels: Record<ChannelKey, number>) => {
+  const total = Object.values(channels).reduce((sum, value) => sum + value, 0) || 1;
+  const normalised = Object.fromEntries(
+    (Object.entries(channels) as [ChannelKey, number][]).map(([key, value]) => [key, Number((value / total).toFixed(4))])
+  ) as Record<ChannelKey, number>;
+  return normalised;
+};
+
+const scoreImpactInternal = (
+  channels: Record<ChannelKey, number>,
+  offer: Campaign['offer']
+): Pick<Campaign['kpis'], 'cvr' | 'arpuDelta' | 'paybackMo' | 'gm12' | 'netAdds' | 'npsDelta'> => {
+  const mix = normaliseChannels(channels);
+  const channelEffect = Object.entries(mix).reduce(
+    (acc, [key, weight]) => {
+      const effect = CHANNEL_WEIGHTS[key as ChannelKey];
+      acc.cvr += effect.cvr * weight;
+      acc.arpu += effect.arpu * weight;
+      acc.gm12 += effect.gm12 * weight;
+      acc.netAdds += effect.netAdds * weight;
+      acc.payback += effect.payback * weight;
+      acc.nps += effect.nps * weight;
+      return acc;
+    },
+    { cvr: 0, arpu: 0, gm12: 0, netAdds: 0, payback: 0, nps: 0 }
+  );
+
+  const priceDiff = offer.price - BASE_OFFER.price;
+  const promoValueDiff = offer.promoValue - BASE_OFFER.promoValue;
+  const promoMonthsDiff = offer.promoMonths - BASE_OFFER.promoMonths;
+  const deviceDiff = offer.deviceSubsidy - BASE_OFFER.deviceSubsidy;
+
+  const offerEffect = {
+    cvr:
+      priceDiff * -0.018 +
+      promoValueDiff * 0.0025 +
+      promoMonthsDiff * 0.12 +
+      deviceDiff * 0.0018,
+    arpu:
+      priceDiff * 0.055 +
+      promoValueDiff * -0.009 +
+      promoMonthsDiff * -0.08 +
+      deviceDiff * -0.003,
+    gm12:
+      priceDiff * 1100 +
+      promoValueDiff * -160 +
+      promoMonthsDiff * -9000 +
+      deviceDiff * -420,
+    netAdds:
+      priceDiff * -6 +
+      promoValueDiff * 4.5 +
+      promoMonthsDiff * 120 +
+      deviceDiff * 1.8,
+    payback:
+      priceDiff * 0.011 +
+      promoValueDiff * 0.004 +
+      promoMonthsDiff * 0.22 +
+      deviceDiff * 0.005,
+    nps:
+      priceDiff * 0.03 +
+      promoValueDiff * 0.018 +
+      promoMonthsDiff * 0.08 +
+      deviceDiff * 0.012
+  };
+
+  const result = {
+    cvr: clamp(BASE_METRICS.cvr + channelEffect.cvr + offerEffect.cvr, 0.6, 9),
+    arpuDelta: Number((BASE_METRICS.arpuDelta + channelEffect.arpu + offerEffect.arpu).toFixed(2)),
+    gm12: Math.round(clamp(BASE_METRICS.gm12 + channelEffect.gm12 + offerEffect.gm12, 120_000, 2_200_000)),
+    netAdds: Math.round(clamp(BASE_METRICS.netAdds + channelEffect.netAdds + offerEffect.netAdds, 420, 9800)),
+    paybackMo: Number(clamp(BASE_METRICS.paybackMo + channelEffect.payback + offerEffect.payback, 3, 18).toFixed(2)),
+    npsDelta: Number((BASE_METRICS.npsDelta + channelEffect.nps + offerEffect.nps).toFixed(2))
+  };
+
+  return result;
+};
+
+const randomBetween = (min: number, max: number) => Math.random() * (max - min) + min;
+
+const nextTelemetryPoint = (prev: TelemetryPoint | undefined, campaign: Campaign): TelemetryPoint => {
+  const anchor = campaign.kpis;
+  if (!prev) {
+    return {
+      t: Date.now(),
+      cvr: anchor.cvr,
+      arpuDelta: anchor.arpuDelta,
+      netAdds: anchor.netAdds,
+      churnDelta: campaign.agent === 'Retention' ? -0.4 : 0.2
+    };
+  }
+
+  const smoothing = 0.18;
+  const cvr = clamp(
+    prev.cvr + randomBetween(-0.12, 0.12) + (anchor.cvr - prev.cvr) * smoothing,
+    0.4,
+    9.5
+  );
+  const arpuDelta = clamp(
+    prev.arpuDelta + randomBetween(-0.25, 0.28) + (anchor.arpuDelta - prev.arpuDelta) * 0.16,
+    -4,
+    18
+  );
+  const netAdds = clamp(
+    prev.netAdds + randomBetween(-90, 110) + (anchor.netAdds - prev.netAdds) * 0.22,
+    220,
+    12_000
+  );
+  const churnDeltaBase = campaign.agent === 'Retention' ? -0.25 : 0.18;
+  const churnDelta = clamp(
+    prev.churnDelta + randomBetween(-0.05, 0.06) + churnDeltaBase * 0.1,
+    -2.2,
+    2.4
+  );
+
+  return {
+    t: Date.now(),
+    cvr: Number(cvr.toFixed(2)),
+    arpuDelta: Number(arpuDelta.toFixed(2)),
+    netAdds: Math.round(netAdds),
+    churnDelta: Number(churnDelta.toFixed(2))
+  };
+};
+
+const initialCampaign: Campaign = {
+  id: 'cmp_001',
+  name: 'Premium Network Loyalists — Family Coverage Maximizers',
+  cohorts: [
+    { id: 'seg-premium', name: 'Premium Network Loyalists', size: 128_000 },
+    { id: 'seg-family', name: 'Family Coverage Maximizers', size: 82_000 }
+  ],
+  status: 'Running',
+  channels: normaliseChannels({ Search: 0.28, Social: 0.22, Email: 0.18, Retail: 0.2, Field: 0.12 }),
+  offer: {
+    price: 85,
+    promoMonths: 4,
+    promoValue: 180,
+    deviceSubsidy: 220
+  },
+  kpis: {
+    cvr: 4.1,
+    arpuDelta: 7.4,
+    paybackMo: 6.8,
+    gm12: 1_180_000,
+    netAdds: 4860,
+    npsDelta: 6.3
+  },
+  agent: 'Acquisition',
+  createdAt: Date.now() - 1000 * 60 * 60 * 24 * 12,
+  lastUpdate: Date.now() - 1000 * 60 * 60 * 2
+};
+
+const seedTelemetry = (): TelemetryPoint[] => {
+  const points: TelemetryPoint[] = [];
+  let prev: TelemetryPoint | undefined;
+  for (let i = 0; i < 16; i += 1) {
+    prev = nextTelemetryPoint(prev, initialCampaign);
+    points.push({ ...prev, t: Date.now() - (15 - i) * 1000 * 60 * 6 });
+  }
+  return points;
+};
+
+const initialState: AppStoreState = {
+  campaigns: [initialCampaign],
+  monitoring: {
+    streams: {
+      [initialCampaign.id]: seedTelemetry()
+    }
+  },
+  agentActions: {
+    [initialCampaign.id]: [
+      {
+        id: makeId(),
+        campaignId: initialCampaign.id,
+        timestamp: Date.now() - 1000 * 60 * 45,
+        summary: 'Rebalanced Search up +4% to capture intent from premium switchers.',
+        lift: 0.6,
+        status: 'Applied',
+        details: 'Projected GM12 lift +$42K'
+      }
+    ]
+  },
+  autoOptimize: {
+    [initialCampaign.id]: false
+  }
+};
+
+const AppStoreContext = React.createContext<AppStoreValue | undefined>(undefined);
+
+export const AppStoreProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, setState] = React.useState<AppStoreState>(initialState);
+
+  const launchCampaign = React.useCallback((payload: LaunchPayload): Campaign => {
+    const now = Date.now();
+    const kpis = payload.kpis ?? scoreImpactInternal(payload.channels, payload.offer);
+    const campaign: Campaign = {
+      id: makeId(),
+      name: payload.name,
+      cohorts: payload.cohorts,
+      status: 'Running',
+      channels: normaliseChannels(payload.channels),
+      offer: payload.offer,
+      kpis,
+      agent: payload.agent,
+      createdAt: now,
+      lastUpdate: now
+    };
+
+    setState((prev) => {
+      const points: TelemetryPoint[] = [];
+      let prevPoint: TelemetryPoint | undefined;
+      for (let i = 0; i < 8; i += 1) {
+        prevPoint = nextTelemetryPoint(prevPoint, campaign);
+        points.push({ ...prevPoint, t: now - (7 - i) * 1000 * 60 * 6 });
+      }
+      return {
+        campaigns: [campaign, ...prev.campaigns],
+        monitoring: {
+          streams: {
+            ...prev.monitoring.streams,
+            [campaign.id]: points
+          }
+        },
+        agentActions: {
+          ...prev.agentActions,
+          [campaign.id]: [
+            {
+              id: makeId(),
+              campaignId: campaign.id,
+              timestamp: now,
+              summary: 'Campaign launched from Offering Designer hand-off.',
+              lift: 0,
+              status: 'Applied',
+              details: 'Baseline telemetry initialised.'
+            }
+          ]
+        },
+        autoOptimize: {
+          ...prev.autoOptimize,
+          [campaign.id]: false
+        }
+      };
+    });
+
+    return campaign;
+  }, []);
+
+  const updateCampaign = React.useCallback((id: string, patch: Partial<Campaign>) => {
+    setState((prev) => {
+      const campaigns = prev.campaigns.map((campaign) =>
+        campaign.id === id ? { ...campaign, ...patch, lastUpdate: Date.now() } : campaign
+      );
+      return { ...prev, campaigns };
+    });
+  }, []);
+
+  const toggleStatus = React.useCallback((id: string) => {
+    setState((prev) => {
+      const campaigns = prev.campaigns.map((campaign) => {
+        if (campaign.id !== id) return campaign;
+        const status = campaign.status === 'Running' ? 'Paused' : 'Running';
+        return { ...campaign, status, lastUpdate: Date.now() };
+      });
+      return { ...prev, campaigns };
+    });
+  }, []);
+
+  const applyTune = React.useCallback(
+    (campaign: Campaign, patch: {
+      channels?: Partial<Record<ChannelKey, number>>;
+      offer?: Partial<Campaign['offer']>;
+    }): Campaign => {
+      const nextChannels = normaliseChannels({ ...campaign.channels, ...patch.channels });
+      const nextOffer = { ...campaign.offer, ...patch.offer };
+      const kpis = scoreImpactInternal(nextChannels, nextOffer);
+      return {
+        ...campaign,
+        channels: nextChannels,
+        offer: nextOffer,
+        kpis,
+        lastUpdate: Date.now()
+      };
+    },
+    []
+  );
+
+  const tuneCampaign = React.useCallback(
+    (id: string, patch: { channels?: Partial<Record<ChannelKey, number>>; offer?: Partial<Campaign['offer']> }) => {
+      let updatedCampaign: Campaign | undefined;
+      setState((prev) => {
+        const campaigns = prev.campaigns.map((campaign) => {
+          if (campaign.id !== id) return campaign;
+          updatedCampaign = applyTune(campaign, patch);
+          return updatedCampaign;
+        });
+        const monitoring = { ...prev.monitoring };
+        if (updatedCampaign) {
+          const stream = prev.monitoring.streams[id] ?? [];
+          const nextPoint = nextTelemetryPoint(stream[stream.length - 1], updatedCampaign);
+          monitoring.streams = {
+            ...prev.monitoring.streams,
+            [id]: [...stream.slice(-60), nextPoint]
+          };
+        }
+        return {
+          ...prev,
+          campaigns,
+          monitoring
+        };
+      });
+      return updatedCampaign;
+    },
+    [applyTune]
+  );
+
+  const setAutoOptimize = React.useCallback((id: string, value: boolean) => {
+    setState((prev) => ({
+      ...prev,
+      autoOptimize: { ...prev.autoOptimize, [id]: value }
+    }));
+  }, []);
+
+  const logAction = React.useCallback(
+    (campaignId: string, action: Omit<AgentAction, 'id' | 'campaignId' | 'timestamp'>) => {
+      setState((prev) => {
+        const entry: AgentAction = {
+          ...action,
+          id: makeId(),
+          campaignId,
+          timestamp: Date.now()
+        };
+        const list = prev.agentActions[campaignId] ?? [];
+        return {
+          ...prev,
+          agentActions: {
+            ...prev.agentActions,
+            [campaignId]: [entry, ...list].slice(0, 12)
+          }
+        };
+      });
+    },
+    []
+  );
+
+  const estimateImpact = React.useCallback(
+    (campaign: Campaign, deltas: { channels?: Partial<Record<ChannelKey, number>>; offer?: Partial<Campaign['offer']> }) => {
+      const nextCampaign = applyTune(campaign, deltas);
+      return {
+        next: nextCampaign.kpis,
+        delta: {
+          cvr: Number((nextCampaign.kpis.cvr - campaign.kpis.cvr).toFixed(2)),
+          arpuDelta: Number((nextCampaign.kpis.arpuDelta - campaign.kpis.arpuDelta).toFixed(2)),
+          gm12: Number((nextCampaign.kpis.gm12 - campaign.kpis.gm12).toFixed(0)),
+          netAdds: Number((nextCampaign.kpis.netAdds - campaign.kpis.netAdds).toFixed(0)),
+          paybackMo: Number((nextCampaign.kpis.paybackMo - campaign.kpis.paybackMo).toFixed(2)),
+          npsDelta: Number((nextCampaign.kpis.npsDelta - campaign.kpis.npsDelta).toFixed(2))
+        }
+      };
+    },
+    [applyTune]
+  );
+
+  React.useEffect(() => {
+    const interval = window.setInterval(() => {
+      setState((prev) => {
+        let mutated = false;
+        const streams: Monitoring['streams'] = { ...prev.monitoring.streams };
+        const campaigns = prev.campaigns.map((campaign) => {
+          if (campaign.status !== 'Running') {
+            return campaign;
+          }
+          const stream = streams[campaign.id] ?? [];
+          const nextPoint = nextTelemetryPoint(stream[stream.length - 1], campaign);
+          streams[campaign.id] = [...stream.slice(-60), nextPoint];
+          mutated = true;
+          return campaign;
+        });
+        if (!mutated) return prev;
+        return {
+          ...prev,
+          campaigns,
+          monitoring: { streams }
+        };
+      });
+    }, 6000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  React.useEffect(() => {
+    const interval = window.setInterval(() => {
+      setState((prev) => {
+        let mutated = false;
+        const streams: Monitoring['streams'] = { ...prev.monitoring.streams };
+        const campaigns = prev.campaigns.map((campaign) => {
+          if (!prev.autoOptimize[campaign.id] || campaign.status !== 'Running') {
+            return campaign;
+          }
+          mutated = true;
+          const randomChannel = (Object.keys(campaign.channels) as ChannelKey[])[
+            Math.floor(Math.random() * 5)
+          ];
+          const direction = Math.random() > 0.5 ? 0.02 : -0.02;
+          const channelPatch: Partial<Record<ChannelKey, number>> = {
+            [randomChannel]: campaign.channels[randomChannel] + direction
+          };
+          const tuned = applyTune(campaign, { channels: channelPatch });
+          const existing = streams[campaign.id] ?? [];
+          const nextPoint = nextTelemetryPoint(existing[existing.length - 1], tuned);
+          streams[campaign.id] = [...existing, nextPoint].slice(-60);
+          return tuned;
+        });
+        if (!mutated) return prev;
+        const agentActions = { ...prev.agentActions };
+        campaigns.forEach((campaign) => {
+          if (!prev.autoOptimize[campaign.id]) return;
+          const list = agentActions[campaign.id] ?? [];
+          const entry: AgentAction = {
+            id: makeId(),
+            campaignId: campaign.id,
+            timestamp: Date.now(),
+            summary: 'Auto-optimize nudged mix ±2% based on live telemetry.',
+            lift: 0.3,
+            status: 'Applied',
+            details: 'Auto agent blended Search/Social reach.'
+          };
+          agentActions[campaign.id] = [entry, ...list].slice(0, 12);
+        });
+        return {
+          ...prev,
+          campaigns,
+          monitoring: { streams },
+          agentActions
+        };
+      });
+    }, 12_000);
+    return () => window.clearInterval(interval);
+  }, [applyTune]);
+
+  const value = React.useMemo<AppStoreValue>(() => ({
+    campaigns: state.campaigns,
+    monitoring: state.monitoring,
+    agentActions: state.agentActions,
+    autoOptimize: state.autoOptimize,
+    launchCampaign,
+    updateCampaign,
+    toggleStatus,
+    tuneCampaign,
+    setAutoOptimize,
+    logAction,
+    scoreImpact: scoreImpactInternal,
+    estimateImpact
+  }), [
+    state.campaigns,
+    state.monitoring,
+    state.agentActions,
+    state.autoOptimize,
+    launchCampaign,
+    updateCampaign,
+    toggleStatus,
+    tuneCampaign,
+    setAutoOptimize,
+    logAction,
+    estimateImpact
+  ]);
+
+  return <AppStoreContext.Provider value={value}>{children}</AppStoreContext.Provider>;
+};
+
+export const useAppStore = () => {
+  const ctx = React.useContext(AppStoreContext);
+  if (!ctx) {
+    throw new Error('useAppStore must be used within AppStoreProvider');
+  }
+  return ctx;
+};
+
+export const appStoreUtils = {
+  scoreImpact: scoreImpactInternal,
+  nextTelemetryPoint
+};
+

--- a/src/store/global.ts
+++ b/src/store/global.ts
@@ -1,0 +1,209 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { assumptionsSeed, channelsSeed, competitorsSeed, defaultCampaign, microSegmentsSeed, offersSeed, segmentsSeed } from '../data/seeds';
+
+type IdMap<T extends { id: string }> = Record<string, T>;
+
+export type Assumptions = {
+  grossMarginRate: number;
+  servicingCostPerSubMo: number;
+  deviceSubsidyAmortMo: number;
+  executionCost: number;
+};
+
+export type Segment = {
+  id: string;
+  name: string;
+  size: number;
+  traits: string[];
+  priceSensitivity: number;
+  valueSensitivity: number;
+  region: string;
+  notes?: string;
+};
+
+export type Competitor = {
+  id: string;
+  name: string;
+  basePrice: number;
+  promoDepth: number;
+  coverageScore: number;
+  valueScore: number;
+};
+
+export type OfferArchetype = {
+  id: string;
+  name: string;
+  monthlyPrice: number;
+  promoMonths: number;
+  promoValue: number;
+  deviceSubsidy: number;
+  bundleFlags: string[];
+};
+
+export type Channel = {
+  id: string;
+  name: string;
+  cac: number;
+  eff: number;
+};
+
+export type MicroSegment = {
+  id: string;
+  parentSegmentId: string;
+  name: string;
+  sizeShare: number;
+  traits: string[];
+  attractiveness: number;
+};
+
+export type CampaignPlan = {
+  audienceIds: string[];
+  offerByAudience: Record<string, OfferArchetype>;
+  channelMixByAudience: Record<string, Record<string, number>>;
+  budgetTotal: number;
+  guardrails: { cacCeiling?: number; paybackTarget?: number };
+};
+
+export type GlobalState = {
+  assumptions: Assumptions;
+  segments: Segment[];
+  competitors: Competitor[];
+  offers: OfferArchetype[];
+  channels: Channel[];
+  activeFilters: Record<string, any>;
+  recommendedSegmentIds: string[];
+  cartSegmentIds: string[];
+  activeSegmentId?: string;
+  microSegmentsByParent: Record<string, MicroSegment[]>;
+  selectedMicroIds: string[];
+  campaign: CampaignPlan;
+  setFilters: (patch: Record<string, any>) => void;
+  setRecommendedSegmentIds: (ids: string[]) => void;
+  addSegmentToCart: (id: string) => void;
+  removeSegmentFromCart: (id: string) => void;
+  setActiveSegment: (id?: string) => void;
+  setSelectedMicro: (ids: string[]) => void;
+  initCampaignFromSelection: () => void;
+  updateCampaign: (partial: Partial<CampaignPlan>) => void;
+  hydrate: () => void;
+  persist: () => void;
+};
+
+const STORAGE_KEY = 'sbm-global-state-v1';
+
+const baseState = {
+  assumptions: assumptionsSeed,
+  segments: segmentsSeed,
+  competitors: competitorsSeed,
+  offers: offersSeed,
+  channels: channelsSeed,
+  activeFilters: {},
+  recommendedSegmentIds: segmentsSeed.map((s) => s.id),
+  cartSegmentIds: [] as string[],
+  activeSegmentId: segmentsSeed[0]?.id,
+  microSegmentsByParent: microSegmentsSeed,
+  selectedMicroIds: [] as string[],
+  campaign: defaultCampaign
+};
+
+const withDevtools = devtools<GlobalState>((set, get) => ({
+  ...baseState,
+  setFilters: (patch) => {
+    const next = { ...get().activeFilters, ...patch };
+    Object.keys(next).forEach((key) => {
+      if (next[key] === undefined || next[key] === '') {
+        delete next[key];
+      }
+    });
+    set({ activeFilters: next });
+    get().persist();
+  },
+  setRecommendedSegmentIds: (ids) => {
+    set({ recommendedSegmentIds: ids });
+    get().persist();
+  },
+  addSegmentToCart: (id) => {
+    const cart = new Set(get().cartSegmentIds);
+    cart.add(id);
+    set({ cartSegmentIds: Array.from(cart) });
+    get().persist();
+  },
+  removeSegmentFromCart: (id) => {
+    set({ cartSegmentIds: get().cartSegmentIds.filter((seg) => seg !== id) });
+    get().persist();
+  },
+  setActiveSegment: (id) => {
+    set({ activeSegmentId: id });
+    get().persist();
+  },
+  setSelectedMicro: (ids) => {
+    set({ selectedMicroIds: ids });
+    get().persist();
+  },
+  initCampaignFromSelection: () => {
+    const { selectedMicroIds, offers, channels, campaign } = get();
+    if (selectedMicroIds.length === 0) return;
+    const defaultOffer = offers[0];
+    const defaultMix: Record<string, number> = {};
+    channels.forEach((ch) => {
+      defaultMix[ch.id] = ch.id === 'ch-search' ? 0.3 : ch.id === 'ch-social' ? 0.25 : ch.id === 'ch-email' ? 0.15 : 0.15;
+    });
+    const normalised = Object.entries(defaultMix).reduce((acc, [id, val]) => {
+      acc[id] = val;
+      return acc;
+    }, {} as Record<string, number>);
+    const offerByAudience: Record<string, OfferArchetype> = {};
+    const channelMixByAudience: Record<string, Record<string, number>> = {};
+    selectedMicroIds.forEach((id) => {
+      offerByAudience[id] = campaign.offerByAudience[id] ?? defaultOffer;
+      channelMixByAudience[id] = campaign.channelMixByAudience[id] ?? normalised;
+    });
+    set({
+      campaign: {
+        ...campaign,
+        audienceIds: selectedMicroIds,
+        offerByAudience,
+        channelMixByAudience
+      }
+    });
+    get().persist();
+  },
+  updateCampaign: (partial) => {
+    set({ campaign: { ...get().campaign, ...partial } });
+    get().persist();
+  },
+  hydrate: () => {
+    if (typeof window === 'undefined') return;
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      const parsed = JSON.parse(saved) as Partial<GlobalState>;
+      set({
+        ...baseState,
+        ...parsed,
+        campaign: { ...defaultCampaign, ...parsed.campaign }
+      });
+    }
+  },
+  persist: () => {
+    if (typeof window === 'undefined') return;
+    const state = get();
+    const payload: Partial<GlobalState> = {
+      activeFilters: state.activeFilters,
+      recommendedSegmentIds: state.recommendedSegmentIds,
+      cartSegmentIds: state.cartSegmentIds,
+      activeSegmentId: state.activeSegmentId,
+      selectedMicroIds: state.selectedMicroIds,
+      campaign: state.campaign
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  }
+}));
+
+export const useGlobalStore = create(withDevtools);
+
+export const segmentsById = (): IdMap<Segment> =>
+  useGlobalStore.getState().segments.reduce((acc, seg) => {
+    acc[seg.id] = seg;
+    return acc;
+  }, {} as IdMap<Segment>);

--- a/src/tabs/ExecutionHub.tsx
+++ b/src/tabs/ExecutionHub.tsx
@@ -1,0 +1,643 @@
+import React from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from 'recharts';
+import { useAppStore, Campaign, ChannelKey } from '../store/AppStore';
+import KpiTile from '../components/KpiTile';
+import Info from '../components/Info';
+import Section from '../components/Section';
+import MiniBadge from '../components/MiniBadge';
+import TrendChip from '../components/TrendChip';
+import { useToast } from '../components/ToastProvider';
+
+const statusTone: Record<Campaign['status'], string> = {
+  Planned: 'bg-slate-500/20 text-slate-200',
+  Running: 'bg-emerald-500/20 text-emerald-200',
+  Paused: 'bg-amber-500/20 text-amber-100',
+  Completed: 'bg-slate-700/40 text-slate-300'
+};
+
+type ExecLocationState = {
+  selectedCampaignId?: string;
+  fromLaunch?: boolean;
+  pendingDeltas?: {
+    channels?: Partial<Record<ChannelKey, number>>;
+    offer?: Partial<Campaign['offer']>;
+  };
+};
+
+const channelKeys: ChannelKey[] = ['Search', 'Social', 'Email', 'Retail', 'Field'];
+
+const ExecutionHub: React.FC = () => {
+  const {
+    campaigns,
+    monitoring,
+    toggleStatus,
+    tuneCampaign,
+    estimateImpact,
+    agentActions,
+    logAction,
+    setAutoOptimize,
+    autoOptimize
+  } = useAppStore();
+  const { pushToast } = useToast();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const locationState = (location.state as ExecLocationState) ?? {};
+
+  const [statusFilter, setStatusFilter] = React.useState<'all' | Campaign['status']>('all');
+  const [agentFilter, setAgentFilter] = React.useState<'all' | Campaign['agent']>('all');
+  const [channelFilter, setChannelFilter] = React.useState<'all' | ChannelKey>('all');
+  const [selectedId, setSelectedId] = React.useState<string>(() => locationState.selectedCampaignId ?? campaigns[0]?.id ?? '');
+  const [showLaunchChip, setShowLaunchChip] = React.useState<boolean>(Boolean(locationState.fromLaunch));
+  const [pendingPrefill, setPendingPrefill] = React.useState(locationState.pendingDeltas);
+
+  React.useEffect(() => {
+    if (locationState.selectedCampaignId) {
+      setSelectedId(locationState.selectedCampaignId);
+    }
+    if (locationState.fromLaunch) {
+      setShowLaunchChip(true);
+      window.setTimeout(() => setShowLaunchChip(false), 2800);
+    }
+    if (locationState.pendingDeltas) {
+      setPendingPrefill(locationState.pendingDeltas);
+    }
+    if (location.state) {
+      navigate(location.pathname, { replace: true, state: null });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const filteredCampaigns = React.useMemo(() => {
+    return campaigns.filter((campaign) => {
+      if (statusFilter !== 'all' && campaign.status !== statusFilter) return false;
+      if (agentFilter !== 'all' && campaign.agent !== agentFilter) return false;
+      if (channelFilter !== 'all' && (campaign.channels[channelFilter] ?? 0) <= 0.01) return false;
+      return true;
+    });
+  }, [agentFilter, campaigns, channelFilter, statusFilter]);
+
+  React.useEffect(() => {
+    if (filteredCampaigns.length === 0) return;
+    if (!filteredCampaigns.some((campaign) => campaign.id === selectedId)) {
+      setSelectedId(filteredCampaigns[0].id);
+    }
+  }, [filteredCampaigns, selectedId]);
+
+  const selectedCampaign = campaigns.find((campaign) => campaign.id === selectedId);
+
+  const [channelDraft, setChannelDraft] = React.useState<Record<ChannelKey, number>>(() => {
+    const base = selectedCampaign?.channels ?? {
+      Search: 0.22,
+      Social: 0.22,
+      Email: 0.18,
+      Retail: 0.2,
+      Field: 0.18
+    };
+    return channelKeys.reduce(
+      (acc, key) => {
+        acc[key] = Number(((base[key] ?? 0) * 100).toFixed(1));
+        return acc;
+      },
+      {} as Record<ChannelKey, number>
+    );
+  });
+  const [offerDraft, setOfferDraft] = React.useState(() => selectedCampaign?.offer ?? {
+    price: 79,
+    promoMonths: 3,
+    promoValue: 150,
+    deviceSubsidy: 200
+  });
+  const [preview, setPreview] = React.useState<ReturnType<typeof estimateImpact> | null>(null);
+
+  React.useEffect(() => {
+    if (!selectedCampaign) return;
+    setChannelDraft(
+      channelKeys.reduce((acc, key) => {
+        acc[key] = Number(((selectedCampaign.channels[key] ?? 0) * 100).toFixed(1));
+        return acc;
+      }, {} as Record<ChannelKey, number>)
+    );
+    setOfferDraft(selectedCampaign.offer);
+  }, [selectedCampaign?.id]);
+
+  React.useEffect(() => {
+    if (!selectedCampaign || !pendingPrefill) return;
+    if (pendingPrefill.channels) {
+      setChannelDraft((prev) => {
+        const next = { ...prev };
+        channelKeys.forEach((key) => {
+          if (pendingPrefill.channels && pendingPrefill.channels[key] !== undefined) {
+            next[key] = Number(((pendingPrefill.channels[key] ?? 0) * 100).toFixed(1));
+          }
+        });
+        return rebalance(next);
+      });
+    }
+    if (pendingPrefill.offer) {
+      setOfferDraft((prev) => ({ ...prev, ...pendingPrefill.offer }));
+    }
+    setPendingPrefill(undefined);
+  }, [pendingPrefill, selectedCampaign]);
+
+  if (!selectedCampaign) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 text-slate-200">
+        <h2 className="text-lg font-semibold">Execution Hub</h2>
+        <p className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6">No campaigns available yet.</p>
+      </div>
+    );
+  }
+
+  const rebalance = (draft: Record<ChannelKey, number>) => {
+    const total = channelKeys.reduce((sum, key) => sum + draft[key], 0);
+    if (total === 0) return draft;
+    const scale = 100 / total;
+    const scaled = channelKeys.reduce((acc, key) => {
+      acc[key] = Number((draft[key] * scale).toFixed(1));
+      return acc;
+    }, {} as Record<ChannelKey, number>);
+    const adjustTotal = channelKeys.reduce((sum, key) => sum + scaled[key], 0);
+    if (Math.abs(adjustTotal - 100) > 0.5) {
+      const diff = 100 - adjustTotal;
+      scaled[channelKeys[0]] = Number((scaled[channelKeys[0]] + diff).toFixed(1));
+    }
+    return scaled;
+  };
+
+  const handleChannelChange = (key: ChannelKey, value: number) => {
+    setChannelDraft((prev) => rebalance({ ...prev, [key]: value }));
+  };
+
+  const handlePreview = () => {
+    if (!selectedCampaign) return;
+    const previewResult = estimateImpact(selectedCampaign, {
+      channels: channelKeys.reduce((acc, key) => {
+        acc[key] = channelDraft[key] / 100;
+        return acc;
+      }, {} as Record<ChannelKey, number>),
+      offer: offerDraft
+    });
+    setPreview(previewResult);
+  };
+
+  const handleApply = () => {
+    if (!selectedCampaign) return;
+    const updated = tuneCampaign(selectedCampaign.id, {
+      channels: channelKeys.reduce((acc, key) => {
+        acc[key] = channelDraft[key] / 100;
+        return acc;
+      }, {} as Record<ChannelKey, number>),
+      offer: offerDraft
+    });
+    if (!updated) return;
+    logAction(selectedCampaign.id, {
+      summary: 'Manual optimisation applied from console.',
+      lift: preview ? Number(preview.delta.gm12 / 1000) : 0.3,
+      status: 'Applied',
+      details: preview ? `GM12 Δ ${preview.delta.gm12.toLocaleString('en-US')}` : 'Mix and offer refreshed.'
+    });
+    setPreview(null);
+    pushToast({ description: 'Optimisation saved to campaign.', variant: 'success' });
+  };
+
+  const handleExport = () => {
+    const blob = new Blob([JSON.stringify(selectedCampaign, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${selectedCampaign.name.replace(/\s+/g, '-')}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    pushToast({ description: 'Campaign JSON exported.', variant: 'default' });
+  };
+
+  const channelChartData = channelKeys.map((key) => ({
+    channel: key,
+    allocation: channelDraft[key],
+    cvr: Number((selectedCampaign.kpis.cvr * (selectedCampaign.channels[key] ?? 0)).toFixed(2))
+  }));
+
+  const telemetry = monitoring.streams[selectedCampaign.id] ?? [];
+  const latestTelemetry = telemetry[telemetry.length - 1];
+  const actionLog = agentActions[selectedCampaign.id] ?? [];
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[260px_minmax(0,1fr)_280px]">
+      <aside className="space-y-5">
+        <div className="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-5">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold text-slate-200">Filters</p>
+            <Info
+              title="Campaign filters"
+              body={(
+                <>
+                  <p><strong>How it is used:</strong> Narrow the table to focus on campaigns by lifecycle, owning agent, or the channels deployed.</p>
+                  <p><strong>What it means:</strong> Filters reference live execution metadata gathered from 1P CRM activation logs and synthetic telemetry.</p>
+                </>
+              )}
+            />
+          </div>
+          <div className="mt-4 space-y-4 text-sm">
+            <label className="space-y-1">
+              <span className="text-xs uppercase tracking-wide text-slate-400">Status</span>
+              <select
+                className="w-full rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-sm"
+                value={statusFilter}
+                onChange={(event) => setStatusFilter(event.target.value as typeof statusFilter)}
+              >
+                <option value="all">All</option>
+                <option value="Running">Running</option>
+                <option value="Paused">Paused</option>
+                <option value="Planned">Planned</option>
+                <option value="Completed">Completed</option>
+              </select>
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs uppercase tracking-wide text-slate-400">Agent</span>
+              <select
+                className="w-full rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-sm"
+                value={agentFilter}
+                onChange={(event) => setAgentFilter(event.target.value as typeof agentFilter)}
+              >
+                <option value="all">All</option>
+                <option value="Acquisition">Acquisition</option>
+                <option value="Upsell">Upsell</option>
+                <option value="Retention">Retention</option>
+                <option value="Optimization">Optimization</option>
+              </select>
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs uppercase tracking-wide text-slate-400">Channel</span>
+              <select
+                className="w-full rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-sm"
+                value={channelFilter}
+                onChange={(event) => setChannelFilter(event.target.value as typeof channelFilter)}
+              >
+                <option value="all">All</option>
+                {channelKeys.map((key) => (
+                  <option key={key} value={key}>
+                    {key}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-5 text-sm text-slate-300">
+          <p className="font-semibold text-slate-100">Agent roles</p>
+          <p className="mt-2 leading-relaxed">
+            Acquisition drives first-time growth, Upsell lifts ARPU, Retention protects base, and Optimization tunes mix based on live
+            signals.
+          </p>
+        </div>
+      </aside>
+      <div className="space-y-6">
+        <div className="rounded-3xl border border-slate-800/80 bg-slate-950/70 p-4 shadow-lg shadow-slate-950/40">
+          <div className="overflow-hidden rounded-2xl border border-slate-800/80">
+            <table className="w-full text-sm">
+              <thead className="sticky top-0 bg-slate-900/90 text-xs uppercase tracking-wide text-slate-400">
+                <tr>
+                  <th className="px-4 py-3 text-left">Campaign</th>
+                  <th className="px-4 py-3 text-left">Status</th>
+                  <th className="px-4 py-3 text-right">Cohorts</th>
+                  <th className="px-4 py-3 text-left">Agent</th>
+                  <th className="px-4 py-3 text-right">CVR %</th>
+                  <th className="px-4 py-3 text-right">ARPU Δ</th>
+                  <th className="px-4 py-3 text-right">GM12</th>
+                  <th className="px-4 py-3 text-right">Payback</th>
+                  <th className="px-4 py-3 text-right">Last update</th>
+                  <th className="px-4 py-3 text-right">Open</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredCampaigns.map((campaign) => (
+                  <tr
+                    key={campaign.id}
+                    className={`border-t border-slate-800/60 transition hover:bg-slate-900/70 ${
+                      campaign.id === selectedId ? 'bg-slate-900/80' : ''
+                    }`}
+                    onClick={() => setSelectedId(campaign.id)}
+                  >
+                    <td className="px-4 py-3 text-left">
+                      <div className="flex items-center gap-2">
+                        <MiniBadge tone="emerald">{campaign.cohorts.length} cohorts</MiniBadge>
+                        <span className="font-medium text-slate-100">{campaign.name}</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-flex items-center gap-2 rounded-full px-2 py-1 text-xs font-medium ${statusTone[campaign.status]}`}>
+                        <span className="h-1.5 w-1.5 rounded-full bg-current"></span>
+                        {campaign.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">{campaign.cohorts.length}</td>
+                    <td className="px-4 py-3 text-left">{campaign.agent}</td>
+                    <td className="px-4 py-3 text-right">{campaign.kpis.cvr.toFixed(2)}%</td>
+                    <td className="px-4 py-3 text-right">{campaign.kpis.arpuDelta.toFixed(2)}</td>
+                    <td className="px-4 py-3 text-right">${campaign.kpis.gm12.toLocaleString('en-US')}</td>
+                    <td className="px-4 py-3 text-right">{campaign.kpis.paybackMo.toFixed(1)}</td>
+                    <td className="px-4 py-3 text-right text-slate-400">
+                      {new Date(campaign.lastUpdate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        className="rounded-full border border-emerald-500/60 px-3 py-1 text-xs font-semibold text-emerald-200"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          setSelectedId(campaign.id);
+                        }}
+                      >
+                        Focus
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div className="space-y-6">
+          <Section
+            title="Performance snapshot"
+            info={{
+              title: 'Performance snapshot',
+              body: (
+                <>
+                  <p><strong>How it is used:</strong> Scan the conversion, value, profitability, and loyalty signals the team monitors hourly.</p>
+                  <p><strong>What it means:</strong> KPIs combine 1P CRM contribution, synthetic activation curves, and modeled service perceptions.</p>
+                </>
+              )
+            }}
+            actions={
+              showLaunchChip ? (
+                <span className="rounded-full border border-emerald-400/60 bg-emerald-500/20 px-3 py-1 text-xs font-semibold text-emerald-100">
+                  In flight
+                </span>
+              ) : null
+            }
+          >
+            <div className="grid gap-4 sm:grid-cols-3 lg:grid-cols-6">
+              <KpiTile label="CVR" value={selectedCampaign.kpis.cvr.toFixed(2)} suffix="%" />
+              <KpiTile label="ARPU Δ" value={selectedCampaign.kpis.arpuDelta.toFixed(2)} suffix="$" />
+              <KpiTile label="GM12" value={`$${selectedCampaign.kpis.gm12.toLocaleString('en-US')}`} />
+              <KpiTile label="Net adds" value={selectedCampaign.kpis.netAdds} />
+              <KpiTile label="NPS Δ" value={selectedCampaign.kpis.npsDelta.toFixed(1)} suffix="pts" />
+              <KpiTile label="Payback" value={selectedCampaign.kpis.paybackMo.toFixed(1)} suffix="mo" />
+            </div>
+          </Section>
+
+          <Section
+            title="Channel breakdown"
+            info={{
+              title: 'Channel breakdown',
+              body: (
+                <>
+                  <p><strong>How it is used:</strong> See how delivery mix and channel-led conversion are trending before you tune allocations.</p>
+                  <p><strong>What it means:</strong> Delivery % reflects booked spend share; CVR is modeled from activation logs and demo telemetry.</p>
+                </>
+              )
+            }}
+          >
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={channelChartData}>
+                  <XAxis dataKey="channel" stroke="#94a3b8" />
+                  <YAxis stroke="#94a3b8" />
+                  <Tooltip cursor={{ fill: 'rgba(15,23,42,0.6)' }} contentStyle={{ background: '#020617', borderRadius: 12 }} />
+                  <Legend />
+                  <Bar dataKey="allocation" name="Allocation %" fill="#34d399" radius={[6, 6, 0, 0]} />
+                  <Bar dataKey="cvr" name="CVR contribution" fill="#6366f1" radius={[6, 6, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </Section>
+
+          <Section
+            title="Optimization console"
+            info={{
+              title: 'Optimization console',
+              body: (
+                <>
+                  <p><strong>How it is used:</strong> Adjust channel weights and offer levers, preview the modeled impact, then commit the change.</p>
+                  <p><strong>What it means:</strong> Estimates blend synthetic propensity models with live telemetry heuristics to show directional lift.</p>
+                </>
+              )
+            }}
+            actions={
+              <label className="inline-flex items-center gap-2 text-xs text-slate-300">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border border-slate-600 bg-slate-900"
+                  checked={autoOptimize[selectedCampaign.id] ?? false}
+                  onChange={(event) => {
+                    setAutoOptimize(selectedCampaign.id, event.target.checked);
+                    pushToast({ description: event.target.checked ? 'Auto-optimize enabled.' : 'Auto-optimize disabled.', variant: 'default' });
+                  }}
+                />
+                Enable auto-optimize
+              </label>
+            }
+          >
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="space-y-4">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-400">Channel mix</p>
+                  <div className="mt-3 space-y-3">
+                    {channelKeys.map((key) => (
+                      <div key={key} className="space-y-1">
+                        <div className="flex items-center justify-between text-xs text-slate-300">
+                          <span>{key}</span>
+                          <span>{channelDraft[key].toFixed(1)}%</span>
+                        </div>
+                        <input
+                          type="range"
+                          min={0}
+                          max={60}
+                          step={1}
+                          value={channelDraft[key]}
+                          onChange={(event) => handleChannelChange(key, Number(event.target.value))}
+                          className="w-full accent-emerald-400"
+                          aria-label={`${key} allocation`}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <button
+                    type="button"
+                    className="rounded-full border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 hover:border-emerald-400/60 hover:text-emerald-200"
+                    onClick={handlePreview}
+                  >
+                    Preview impact
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-full border border-emerald-500/60 bg-emerald-500/20 px-4 py-2 text-sm font-semibold text-emerald-100"
+                    onClick={handleApply}
+                  >
+                    Apply &amp; save
+                  </button>
+                </div>
+                {preview ? (
+                  <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+                    <p className="font-semibold uppercase tracking-wide text-xs text-emerald-200">Projected lift</p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <TrendChip value={preview.delta.cvr} suffix="pp" />
+                      <TrendChip value={preview.delta.arpuDelta} suffix="$" />
+                      <TrendChip value={preview.delta.gm12} suffix="$" />
+                      <TrendChip value={preview.delta.netAdds} />
+                      <TrendChip value={-preview.delta.paybackMo} suffix="mo" />
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+              <div className="space-y-4">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <label className="space-y-1">
+                    <span className="text-xs uppercase tracking-wide text-slate-400">Price</span>
+                    <input
+                      type="number"
+                      value={offerDraft.price}
+                      onChange={(event) => setOfferDraft((prev) => ({ ...prev, price: Number(event.target.value) }))}
+                      className="w-full rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2"
+                    />
+                  </label>
+                  <label className="space-y-1">
+                    <span className="text-xs uppercase tracking-wide text-slate-400">Promo months</span>
+                    <input
+                      type="number"
+                      value={offerDraft.promoMonths}
+                      onChange={(event) => setOfferDraft((prev) => ({ ...prev, promoMonths: Number(event.target.value) }))}
+                      className="w-full rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2"
+                    />
+                  </label>
+                  <label className="space-y-1">
+                    <span className="text-xs uppercase tracking-wide text-slate-400">Promo value ($)</span>
+                    <input
+                      type="number"
+                      value={offerDraft.promoValue}
+                      onChange={(event) => setOfferDraft((prev) => ({ ...prev, promoValue: Number(event.target.value) }))}
+                      className="w-full rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2"
+                    />
+                  </label>
+                  <label className="space-y-1">
+                    <span className="text-xs uppercase tracking-wide text-slate-400">Device subsidy ($)</span>
+                    <input
+                      type="number"
+                      value={offerDraft.deviceSubsidy}
+                      onChange={(event) => setOfferDraft((prev) => ({ ...prev, deviceSubsidy: Number(event.target.value) }))}
+                      className="w-full rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2"
+                    />
+                  </label>
+                </div>
+                <div className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4 text-sm text-slate-200">
+                  <p className="text-xs uppercase tracking-wide text-slate-400">Latest telemetry</p>
+                  {latestTelemetry ? (
+                    <ul className="mt-2 space-y-2">
+                      <li>CVR {latestTelemetry.cvr.toFixed(2)}%</li>
+                      <li>ARPU Δ {latestTelemetry.arpuDelta.toFixed(2)}</li>
+                      <li>Net adds {latestTelemetry.netAdds.toLocaleString('en-US')}</li>
+                      <li>Churn Δ {latestTelemetry.churnDelta.toFixed(2)} pts</li>
+                    </ul>
+                  ) : (
+                    <p className="mt-2 text-slate-500">Telemetry initialising…</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </Section>
+
+          <Section
+            title="Agent workflow"
+            info={{
+              title: 'Agent workflow',
+              body: (
+                <>
+                  <p><strong>How it is used:</strong> Review the human and AI interventions taken on this campaign to keep leadership informed.</p>
+                  <p><strong>What it means:</strong> Entries combine manual actions and synthetic auto-optimiser nudges with projected lift estimates.</p>
+                </>
+              )
+            }}
+          >
+            <div className="space-y-4">
+              <div className="flex items-center justify-between text-xs text-slate-400">
+                <span>Recent actions</span>
+                <button
+                  type="button"
+                  className="rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold text-slate-200 hover:border-emerald-400/60 hover:text-emerald-200"
+                  onClick={() => {
+                    navigate('/monitoring', { state: { focusCampaignId: selectedCampaign.id } });
+                  }}
+                >
+                  View in Monitoring
+                </button>
+              </div>
+              <ul className="space-y-3 text-sm">
+                {actionLog.map((action) => (
+                  <li key={action.id} className="rounded-xl border border-slate-800/70 bg-slate-950/70 p-3">
+                    <div className="flex items-center justify-between text-xs text-slate-400">
+                      <span>{new Date(action.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+                      <span className="font-semibold text-slate-200">{action.status}</span>
+                    </div>
+                    <p className="mt-2 text-slate-100">{action.summary}</p>
+                    <div className="mt-2 flex items-center justify-between text-xs text-slate-400">
+                      <span>Lift ~{action.lift.toFixed(1)}%</span>
+                      {action.details ? <span>{action.details}</span> : null}
+                    </div>
+                  </li>
+                ))}
+                {actionLog.length === 0 ? (
+                  <li className="rounded-xl border border-slate-800/70 bg-slate-950/70 p-3 text-slate-400">No logged actions yet.</li>
+                ) : null}
+              </ul>
+            </div>
+          </Section>
+        </div>
+      </div>
+      <aside className="space-y-5">
+        <div className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-5">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold text-slate-200">Quick KPIs</p>
+            <Info
+              title="Right rail utilities"
+              body={(
+                <>
+                  <p><strong>How it is used:</strong> Keep the headline metrics and operational controls close while you orchestrate changes.</p>
+                  <p><strong>What it means:</strong> KPIs, status toggles, and exports reflect the latest synthetic telemetry and plan metadata.</p>
+                </>
+              )}
+            />
+          </div>
+          <div className="mt-4 space-y-3">
+            <div className="grid gap-3">
+              <KpiTile label="CVR" value={selectedCampaign.kpis.cvr.toFixed(2)} suffix="%" />
+              <KpiTile label="GM12" value={`$${selectedCampaign.kpis.gm12.toLocaleString('en-US')}`} />
+              <KpiTile label="Net adds" value={selectedCampaign.kpis.netAdds} />
+            </div>
+            <button
+              type="button"
+              className="mt-2 w-full rounded-full border border-emerald-500/60 bg-emerald-500/20 px-4 py-2 text-sm font-semibold text-emerald-100"
+              onClick={() => toggleStatus(selectedCampaign.id)}
+            >
+              {selectedCampaign.status === 'Running' ? 'Pause campaign' : 'Resume campaign'}
+            </button>
+            <button
+              type="button"
+              className="w-full rounded-full border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 hover:border-emerald-400/60 hover:text-emerald-200"
+              onClick={handleExport}
+            >
+              Export JSON
+            </button>
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+};
+
+export default ExecutionHub;
+

--- a/src/tabs/MonitoringDashboard.tsx
+++ b/src/tabs/MonitoringDashboard.tsx
@@ -1,0 +1,479 @@
+import React from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  AreaChart,
+  Area,
+  BarChart,
+  Bar
+} from 'recharts';
+import { useAppStore, ChannelKey, TelemetryPoint } from '../store/AppStore';
+import Info from '../components/Info';
+import Section from '../components/Section';
+import MiniBadge from '../components/MiniBadge';
+import TrendChip from '../components/TrendChip';
+import { useToast } from '../components/ToastProvider';
+
+const channelKeys: ChannelKey[] = ['Search', 'Social', 'Email', 'Retail', 'Field'];
+
+const formatTime = (timestamp: number) => new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+const averageSeries = (streams: TelemetryPoint[][]) => {
+  if (streams.length === 0) return [] as TelemetryPoint[];
+  const minLength = Math.min(...streams.map((stream) => stream.length));
+  const trimmed = streams.map((stream) => stream.slice(stream.length - minLength));
+  return trimmed[0].map((_, index) => {
+    const samples = trimmed.map((stream) => stream[index]);
+    const base = samples[0];
+    const aggregate = samples.reduce(
+      (acc, point) => {
+        acc.cvr += point.cvr;
+        acc.arpuDelta += point.arpuDelta;
+        acc.netAdds += point.netAdds;
+        acc.churnDelta += point.churnDelta;
+        return acc;
+      },
+      { cvr: 0, arpuDelta: 0, netAdds: 0, churnDelta: 0 }
+    );
+    const count = samples.length;
+    return {
+      t: base.t,
+      cvr: Number((aggregate.cvr / count).toFixed(2)),
+      arpuDelta: Number((aggregate.arpuDelta / count).toFixed(2)),
+      netAdds: Math.round(aggregate.netAdds / count),
+      churnDelta: Number((aggregate.churnDelta / count).toFixed(2))
+    };
+  });
+};
+
+const MonitoringDashboard: React.FC = () => {
+  const { campaigns, monitoring } = useAppStore();
+  const { pushToast } = useToast();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const focusCampaignId = (location.state as { focusCampaignId?: string } | null)?.focusCampaignId;
+  const [selectedCampaignId, setSelectedCampaignId] = React.useState<'all' | string>(focusCampaignId ?? 'all');
+  const [range, setRange] = React.useState<30 | 60 | 90>(30);
+  const [insights, setInsights] = React.useState<string[]>([
+    'Email is outperforming Retail on CVR for switch-prone families.',
+    'Social retargeting is boosting ARPU for urban streamers.',
+    'Field teams are driving higher NPS lifts in fiber launch DMAs.'
+  ]);
+
+  React.useEffect(() => {
+    if (focusCampaignId) {
+      setSelectedCampaignId(focusCampaignId);
+      navigate(location.pathname, { replace: true, state: null });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    const pool = [
+      'Email is outperforming Retail on CVR for value seekers.',
+      'Search + Social pairing is lifting net adds in high-churn DMAs.',
+      'Promo months beyond 4 slow payback but raise ARPU in premium tiers.',
+      'Self-serve cohorts react fastest to price drops under $5.',
+      'Field activations improve NPS when bundled with device upgrades.'
+    ];
+    const interval = window.setInterval(() => {
+      setInsights((prev) => {
+        const next = [...prev];
+        const idea = pool[Math.floor(Math.random() * pool.length)];
+        next.shift();
+        next.push(idea);
+        return next;
+      });
+    }, 12_000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const threshold = Date.now() - range * 24 * 60 * 60 * 1000;
+  const runningCampaigns = campaigns.filter((campaign) => campaign.status === 'Running');
+
+  const getStream = (campaignId: string) => (monitoring.streams[campaignId] ?? []).filter((point) => point.t >= threshold);
+
+  const selectedStreams =
+    selectedCampaignId === 'all'
+      ? averageSeries(runningCampaigns.map((campaign) => getStream(campaign.id)))
+      : getStream(selectedCampaignId);
+
+  const metricSparklines = {
+    cvr: selectedStreams.map((point) => ({ t: formatTime(point.t), value: point.cvr })),
+    arpu: selectedStreams.map((point) => ({ t: formatTime(point.t), value: point.arpuDelta })),
+    net: selectedStreams.map((point) => ({ t: formatTime(point.t), value: point.netAdds })),
+    churn: selectedStreams.map((point) => ({ t: formatTime(point.t), value: point.churnDelta }))
+  };
+
+  const activeCampaigns = runningCampaigns.length;
+  const averageCvr = runningCampaigns.length
+    ? runningCampaigns.reduce((sum, campaign) => sum + campaign.kpis.cvr, 0) / runningCampaigns.length
+    : 0;
+  const averageArpu = runningCampaigns.length
+    ? runningCampaigns.reduce((sum, campaign) => sum + campaign.kpis.arpuDelta, 0) / runningCampaigns.length
+    : 0;
+  const totalNetAdds = runningCampaigns.reduce((sum, campaign) => sum + campaign.kpis.netAdds, 0);
+  const averageChurn = selectedStreams.length
+    ? selectedStreams[selectedStreams.length - 1].churnDelta
+    : 0;
+
+  const performanceSeries = selectedStreams.map((point) => ({
+    time: formatTime(point.t),
+    cvr: point.cvr,
+    arpu: point.arpuDelta,
+    netAdds: point.netAdds
+  }));
+
+  const channelEffectiveness = selectedStreams.map((point) => {
+    const baseCampaigns = selectedCampaignId === 'all'
+      ? runningCampaigns
+      : campaigns.filter((campaign) => campaign.id === selectedCampaignId);
+    const entry: Record<string, number | string> = { time: formatTime(point.t) };
+    baseCampaigns.forEach((campaign) => {
+      channelKeys.forEach((key) => {
+        const share = campaign.channels[key] ?? 0;
+        const contribution = point.cvr * share;
+        entry[key] = (entry[key] as number | undefined ?? 0) + Number(contribution.toFixed(2));
+      });
+    });
+    return entry;
+  });
+
+  const cohortTotals = new Map<string, { name: string; cvr: number; arpu: number; count: number }>();
+  runningCampaigns.forEach((campaign) => {
+    campaign.cohorts.forEach((cohort) => {
+      const key = cohort.id;
+      const record = cohortTotals.get(key) ?? { name: cohort.name, cvr: 0, arpu: 0, count: 0 };
+      record.cvr += campaign.kpis.cvr;
+      record.arpu += campaign.kpis.arpuDelta;
+      record.count += 1;
+      cohortTotals.set(key, record);
+    });
+  });
+  const cohortCompare = Array.from(cohortTotals.values())
+    .map((entry) => ({
+      name: entry.name,
+      cvr: Number((entry.cvr / entry.count).toFixed(2)),
+      arpu: Number((entry.arpu / entry.count).toFixed(2))
+    }))
+    .slice(0, 5);
+
+  const leverSuggestions = runningCampaigns.slice(0, 3).map((campaign) => {
+    const suggestion = Math.random() > 0.5 ? 'Search' : 'Email';
+    const delta = suggestion === 'Search' ? 0.04 : 0.03;
+    const recommendation = `Increase ${suggestion} +${Math.round(delta * 100)}% for ${campaign.name}`;
+    const expectedLift = (0.5 + Math.random() * 0.6).toFixed(1);
+    const confidence = Math.random() > 0.6 ? 'High' : 'Medium';
+    return {
+      campaign,
+      recommendation,
+      expectedLift,
+      confidence,
+      deltas: {
+        channels: {
+          [suggestion]: (campaign.channels[suggestion as ChannelKey] ?? 0) + delta
+        }
+      }
+    };
+  });
+
+  const handleExport = () => {
+    const rows = performanceSeries.map((row) => `${row.time},${row.cvr},${row.arpu},${row.netAdds}`);
+    const csv = ['time,cvr,arpu_delta,net_adds', ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'monitoring-export.csv';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    pushToast({ description: 'Monitoring export ready.', variant: 'success' });
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold text-white">Monitoring dashboard</h2>
+          <p className="text-sm text-slate-400">One-glance health of live acquisition plays.</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            className="rounded-full border border-slate-700 bg-slate-900/80 px-4 py-2 text-sm text-slate-200"
+            value={selectedCampaignId}
+            onChange={(event) => setSelectedCampaignId(event.target.value as typeof selectedCampaignId)}
+          >
+            <option value="all">All campaigns</option>
+            {campaigns.map((campaign) => (
+              <option key={campaign.id} value={campaign.id}>
+                {campaign.name}
+              </option>
+            ))}
+          </select>
+          <select
+            className="rounded-full border border-slate-700 bg-slate-900/80 px-4 py-2 text-sm text-slate-200"
+            value={range}
+            onChange={(event) => setRange(Number(event.target.value) as typeof range)}
+          >
+            <option value={30}>Last 30 days</option>
+            <option value={60}>Last 60 days</option>
+            <option value={90}>Last 90 days</option>
+          </select>
+          <button
+            type="button"
+            className="rounded-full border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 hover:border-emerald-400/60 hover:text-emerald-200"
+            onClick={handleExport}
+          >
+            Export CSV
+          </button>
+        </div>
+      </header>
+
+      <div className="grid gap-4 lg:grid-cols-5">
+        {[
+          {
+            label: 'Active campaigns',
+            value: activeCampaigns,
+            spark: metricSparklines.cvr,
+            info: (
+              <>
+                <p><strong>How it is used:</strong> Gauge how many plays are live at any moment.</p>
+                <p><strong>What it means:</strong> Running status combines CRM launch flags and synthetic control states.</p>
+              </>
+            )
+          },
+          {
+            label: 'Average CVR',
+            value: `${averageCvr.toFixed(2)}%`,
+            spark: metricSparklines.cvr,
+            info: (
+              <>
+                <p><strong>How it is used:</strong> Track blended conversion momentum across the active portfolio.</p>
+                <p><strong>What it means:</strong> Calculated from modeled net adds divided by exposed volume.</p>
+              </>
+            )
+          },
+          {
+            label: 'ARPU Δ (12-mo)',
+            value: `$${averageArpu.toFixed(2)}`,
+            spark: metricSparklines.arpu,
+            info: (
+              <>
+                <p><strong>How it is used:</strong> Monitor value lift generated by your campaigns.</p>
+                <p><strong>What it means:</strong> Synthetic blend of upsell attach and usage uplift vs. baseline cohorts.</p>
+              </>
+            )
+          },
+          {
+            label: 'Net adds (rolling)',
+            value: totalNetAdds.toLocaleString('en-US'),
+            spark: metricSparklines.net,
+            info: (
+              <>
+                <p><strong>How it is used:</strong> Gauge subscriber growth potential fed to Finance and Sales.</p>
+                <p><strong>What it means:</strong> Derived from modeled reach * take-rate across all active cohorts.</p>
+              </>
+            )
+          },
+          {
+            label: 'Churn Δ (rolling)',
+            value: `${averageChurn.toFixed(2)} pts`,
+            spark: metricSparklines.churn,
+            info: (
+              <>
+                <p><strong>How it is used:</strong> Keep a pulse on retention risk or lift.</p>
+                <p><strong>What it means:</strong> Based on synthetic churn propensity shifts from telemetry and sentiment.</p>
+              </>
+            )
+          }
+        ].map((tile) => (
+          <div key={tile.label} className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-slate-400">{tile.label}</p>
+                <p className="mt-1 text-xl font-semibold text-white">{tile.value}</p>
+              </div>
+              <Info title={tile.label} body={tile.info} />
+            </div>
+            <div className="mt-3 h-16">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={tile.spark}>
+                  <Line type="monotone" dataKey="value" stroke="#34d399" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Section
+          title="Campaign performance over time"
+          info={{
+            title: 'Performance over time',
+            body: (
+              <>
+                <p><strong>How it is used:</strong> Inspect trend lines for conversion, value, and net adds to catch inflections quickly.</p>
+                <p><strong>What it means:</strong> Cadence aligns with synthetic telemetry updates every six minutes for live plays.</p>
+              </>
+            )
+          }}
+        >
+          <div className="h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={performanceSeries}>
+                <XAxis dataKey="time" stroke="#94a3b8" hide />
+                <YAxis stroke="#94a3b8" />
+                <Tooltip contentStyle={{ background: '#020617', borderRadius: 12 }} />
+                <Legend />
+                <Line type="monotone" dataKey="cvr" name="CVR %" stroke="#34d399" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="arpu" name="ARPU Δ" stroke="#f97316" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="netAdds" name="Net adds" stroke="#60a5fa" strokeWidth={2} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </Section>
+
+        <Section
+          title="Channel effectiveness"
+          info={{
+            title: 'Channel effectiveness',
+            body: (
+              <>
+                <p><strong>How it is used:</strong> Diagnose which channels are delivering conversions at scale right now.</p>
+                <p><strong>What it means:</strong> Effectiveness is modeled conversions weighted by the live mix across campaigns.</p>
+              </>
+            )
+          }}
+        >
+          <div className="h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={channelEffectiveness}>
+                <XAxis dataKey="time" stroke="#94a3b8" hide />
+                <YAxis stroke="#94a3b8" />
+                <Tooltip contentStyle={{ background: '#020617', borderRadius: 12 }} />
+                <Legend />
+                {channelKeys.map((key, index) => (
+                  <Area
+                    key={key}
+                    type="monotone"
+                    dataKey={key}
+                    stackId="1"
+                    stroke={['#34d399', '#60a5fa', '#f97316', '#a78bfa', '#f472b6'][index]}
+                    fill={['#34d399', '#60a5fa', '#f97316', '#a78bfa', '#f472b6'][index]}
+                    fillOpacity={0.35}
+                  />
+                ))}
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        </Section>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Section
+          title="Cohort compare"
+          info={{
+            title: 'Cohort compare',
+            body: (
+              <>
+                <p><strong>How it is used:</strong> Compare conversion and value lift across the top cohorts you activated.</p>
+                <p><strong>What it means:</strong> Cohorts trace back to Segment Studio micro-segments aggregated for this demo.</p>
+              </>
+            )
+          }}
+        >
+          <div className="h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={cohortCompare}>
+                <XAxis dataKey="name" stroke="#94a3b8" />
+                <YAxis stroke="#94a3b8" />
+                <Tooltip contentStyle={{ background: '#020617', borderRadius: 12 }} />
+                <Legend />
+                <Bar dataKey="cvr" name="CVR %" fill="#34d399" radius={[8, 8, 0, 0]} />
+                <Bar dataKey="arpu" name="ARPU Δ" fill="#60a5fa" radius={[8, 8, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </Section>
+
+        <Section
+          title="Best levers right now"
+          info={{
+            title: 'Best levers',
+            body: (
+              <>
+                <p><strong>How it is used:</strong> Act on quick wins surfaced by telemetry heuristics.</p>
+                <p><strong>What it means:</strong> Recommendations simulate impact based on current mix and offer sensitivity.</p>
+              </>
+            )
+          }}
+        >
+          <div className="space-y-4">
+            {leverSuggestions.map((entry) => (
+              <div key={entry.campaign.id} className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-4 text-sm">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="font-semibold text-slate-100">{entry.recommendation}</p>
+                    <p className="text-xs text-slate-400">Confidence: {entry.confidence}</p>
+                  </div>
+                  <TrendChip value={Number(entry.expectedLift)} suffix="%" />
+                </div>
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <MiniBadge tone="emerald">{entry.campaign.name}</MiniBadge>
+                  <button
+                    type="button"
+                    className="rounded-full border border-emerald-500/60 px-3 py-1 text-xs font-semibold text-emerald-100 hover:bg-emerald-500/20"
+                    onClick={() => {
+                      navigate('/execution-hub', {
+                        state: {
+                          selectedCampaignId: entry.campaign.id,
+                          pendingDeltas: entry.deltas
+                        }
+                      });
+                      pushToast({ description: 'Lever sent to Execution Hub.', variant: 'success' });
+                    }}
+                  >
+                    Apply
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Section>
+      </div>
+
+      <Section
+        title="What the system is learning"
+        info={{
+          title: 'Learning loop',
+          body: (
+            <>
+              <p><strong>How it is used:</strong> Socialise takeaways with leadership and adjacent teams.</p>
+              <p><strong>What it means:</strong> Illustrative blend of CRM, activation, and synthetic market signals.</p>
+            </>
+          )
+        }}
+      >
+        <ul className="space-y-2 text-sm text-slate-200">
+          {insights.map((item, index) => (
+            <li key={`${item}-${index}`} className="rounded-xl border border-slate-800/70 bg-slate-950/70 p-3">
+              {item}
+            </li>
+          ))}
+        </ul>
+      </Section>
+    </div>
+  );
+};
+
+export default MonitoringDashboard;
+

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx,jsx,js}'],
+  theme: {
+    extend: {
+      colors: {
+        emerald: {
+          500: '#10b981',
+          600: '#059669'
+        },
+        slate: {
+          700: '#334155',
+          800: '#1e293b'
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript workspace with Tailwind, Zustand persistence, and route structure for the Acquire experience
- implement Market Radar, Segment Studio, and Campaign Designer flows with reusable components, synthetic cohort data, and the tinySim engine for interactive metrics
- add info-popovers, maps, charts, and selection trays so cohorts flow from discovery to campaign design with persisted state

## Testing
- npm install *(fails: registry returns 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_68e56952e0cc832e9f201fe3ecd6e442